### PR TITLE
ci: Add fast validation and Renovate config

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - kubeply-arm64-low-latency

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,95 @@
+---
+name: pr-validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=github-releases depName=rhysd/actionlint
+  ACTIONLINT_VERSION: v1.7.12
+  # renovate: datasource=npm depName=@taplo/cli
+  TAPLO_VERSION: 0.7.0
+
+jobs:
+  actionlint:
+    if: |
+      github.event_name == 'push' ||
+      (!github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on:
+      group: kubeply-low-latency
+      labels: kubeply-arm64-low-latency
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install actionlint
+        run: |
+          set -euo pipefail
+          : "${ACTIONLINT_VERSION:?ACTIONLINT_VERSION is required}"
+          actionlint_version="${ACTIONLINT_VERSION#v}"
+          case "$(uname -m)" in
+            aarch64|arm64)
+              actionlint_arch="arm64"
+              ;;
+            x86_64|amd64)
+              actionlint_arch="amd64"
+              ;;
+            *)
+              echo "Unsupported architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          curl -fsSLo /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/${ACTIONLINT_VERSION}/actionlint_${actionlint_version}_linux_${actionlint_arch}.tar.gz"
+          mkdir -p /tmp/actionlint
+          tar -xzf /tmp/actionlint.tar.gz -C /tmp/actionlint
+          sudo install -m 0755 /tmp/actionlint/actionlint /usr/local/bin/actionlint
+
+      - name: Validate GitHub Actions workflows
+        run: actionlint
+
+  fast-checks:
+    if: |
+      github.event_name == 'push' ||
+      (!github.event.pull_request.draft &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on:
+      group: kubeply-low-latency
+      labels: kubeply-arm64-low-latency
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          # renovate: datasource=pypi depName=uv
+          version: 0.11.7
+
+      - name: Install lint tools
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y jq nodejs npm shellcheck
+
+      - name: Validate file formatting and lint
+        run: ./scripts/lint-files.sh
+
+      - name: Validate repository structure
+        run: ./scripts/validate-structure.sh
+
+      - name: Verify dataset manifests are synchronized
+        run: |
+          set -euo pipefail
+          uvx --from harbor harbor sync datasets/kubernetes-core
+          uvx --from harbor harbor sync datasets/terraform-core
+          npx --yes "@taplo/cli@${TAPLO_VERSION}" fmt "**/*.toml" "!jobs/**"
+          git diff --exit-code -- datasets

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -5,7 +5,7 @@
 [dataset]
 name = "kubeply/kubernetes-core"
 description = "Kubernetes-first infrastructure benchmark scenarios for AI agents."
-keywords = [ "kubernetes", "infrastructure", "benchmark", "agents",]
+keywords = ["kubernetes", "infrastructure", "benchmark", "agents"]
 [[dataset.authors]]
 name = "Kubeply"
 email = "thomas@kubeply.com"
@@ -18,5 +18,4 @@ digest = "sha256:16fb625bf4804478e7f9af7557e221be81e29b3b5a52c95bbbc3f3ff8c57118
 
 [[files]]
 path = "metric.py"
-digest = "sha256:bb6eb31d7e96e7b895f88b63517f078c3d50827da521a1dad40390a5e28b67a4"
-
+digest = "sha256:52299ec1e5986fcc50c3c13eaeef2e66038b9184b0a9cb69c34d886eb7fcf8a7"

--- a/datasets/kubernetes-core/metric.py
+++ b/datasets/kubernetes-core/metric.py
@@ -29,7 +29,9 @@ def main(input_path: Path, output_path: Path):
         rewards.extend(extract_values(json.loads(line)))
 
     mean = sum(rewards) / len(rewards) if rewards else 0
-    pass_rate = sum(1 for reward in rewards if reward >= 1.0) / len(rewards) if rewards else 0
+    pass_rate = (
+        sum(1 for reward in rewards if reward >= 1.0) / len(rewards) if rewards else 0
+    )
 
     output_path.write_text(
         json.dumps(

--- a/datasets/terraform-core/dataset.toml
+++ b/datasets/terraform-core/dataset.toml
@@ -5,7 +5,7 @@
 [dataset]
 name = "kubeply/terraform-core"
 description = "Terraform infrastructure-as-code benchmark scenarios for AI agents."
-keywords = [ "terraform", "infrastructure", "iac", "benchmark", "agents",]
+keywords = ["terraform", "infrastructure", "iac", "benchmark", "agents"]
 [[dataset.authors]]
 name = "Kubeply"
 email = "thomas@kubeply.com"
@@ -15,5 +15,4 @@ tasks = []
 
 [[files]]
 path = "metric.py"
-digest = "sha256:bb6eb31d7e96e7b895f88b63517f078c3d50827da521a1dad40390a5e28b67a4"
-
+digest = "sha256:52299ec1e5986fcc50c3c13eaeef2e66038b9184b0a9cb69c34d886eb7fcf8a7"

--- a/datasets/terraform-core/metric.py
+++ b/datasets/terraform-core/metric.py
@@ -29,7 +29,9 @@ def main(input_path: Path, output_path: Path):
         rewards.extend(extract_values(json.loads(line)))
 
     mean = sum(rewards) / len(rewards) if rewards else 0
-    pass_rate = sum(1 for reward in rewards if reward >= 1.0) / len(rewards) if rewards else 0
+    pass_rate = (
+        sum(1 for reward in rewards if reward >= 1.0) / len(rewards) if rewards else 0
+    )
 
     output_path.write_text(
         json.dumps(

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
+  "dependencyDashboard": true,
+  "ignorePaths": ["jobs/**"],
+  "labels": ["dependencies"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/.*\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n\\s+[A-Z0-9_]+_VERSION: (?<currentValue>[^\\s]+)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/.*\\.ya?ml$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>pypi) depName=(?<depName>[^\\s]+)\\n\\s+version: (?<currentValue>[^\\s]+)"
+      ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^scripts\\/lint-files\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>[a-z-]+) depName=(?<depName>[^\\s]+)\\n[A-Z0-9_]+_VERSION=\"(?<currentValue>[^\"]+)\""
+      ]
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
+    },
+    {
+      "matchFileNames": ["scripts/lint-files.sh", ".github/workflows/*.yaml"],
+      "groupName": "ci tooling"
+    }
+  ]
+}

--- a/scripts/lint-files.sh
+++ b/scripts/lint-files.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "$1 is required"
+}
+
+collect_files() {
+  find . \
+    -path "./.git" -prune -o \
+    -path "./jobs" -prune -o \
+    "$@"
+}
+
+require_command npx
+require_command jq
+require_command shellcheck
+require_command uvx
+
+# renovate: datasource=npm depName=@taplo/cli
+TAPLO_VERSION="0.7.0"
+# renovate: datasource=npm depName=prettier
+PRETTIER_VERSION="3.8.3"
+# renovate: datasource=pypi depName=ruff
+RUFF_VERSION="0.15.10"
+
+toml_files=()
+while IFS= read -r -d "" path; do
+  toml_files+=("$path")
+done < <(collect_files -type f -name "*.toml" -print0)
+if [[ "${#toml_files[@]}" -gt 0 ]]; then
+  npx --yes "@taplo/cli@${TAPLO_VERSION}" fmt --check "${toml_files[@]}"
+  npx --yes "@taplo/cli@${TAPLO_VERSION}" lint "${toml_files[@]}"
+fi
+
+yaml_json_files=()
+while IFS= read -r -d "" path; do
+  yaml_json_files+=("$path")
+done < <(
+  collect_files -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \) -print0
+)
+if [[ "${#yaml_json_files[@]}" -gt 0 ]]; then
+  npx --yes "prettier@${PRETTIER_VERSION}" --check "${yaml_json_files[@]}"
+fi
+
+json_files=()
+while IFS= read -r -d "" path; do
+  json_files+=("$path")
+done < <(collect_files -type f -name "*.json" -print0)
+if [[ "${#json_files[@]}" -gt 0 ]]; then
+  for json_file in "${json_files[@]}"; do
+    jq empty "$json_file" >/dev/null
+  done
+fi
+
+shell_files=()
+while IFS= read -r -d "" path; do
+  shell_files+=("$path")
+done < <(
+  while IFS= read -r -d "" path; do
+    if head -n 1 "$path" | grep -Eq '^#!.*(ba)?sh'; then
+      printf "%s\0" "$path"
+    fi
+  done < <(collect_files -type f \( -name "*.sh" -o -perm -111 \) -print0)
+)
+if [[ "${#shell_files[@]}" -gt 0 ]]; then
+  shellcheck -x "${shell_files[@]}"
+fi
+
+uvx --from "ruff==${RUFF_VERSION}" ruff check .
+uvx --from "ruff==${RUFF_VERSION}" ruff format --check .
+
+echo "file lint ok"


### PR DESCRIPTION
Add a fast PR validation workflow for repository quality checks.

The workflow follows the internal Kubeply runner pattern from platform-delivery and validates GitHub Actions workflows, structured file formatting, repository structure, and Harbor dataset manifest drift without running slower benchmark tasks.

This also adds Renovate configuration so pinned GitHub Actions, actionlint, uv, Taplo, Prettier, and Ruff versions can be maintained automatically. Existing dataset TOML and metric files are normalized so the new checks start from a green state.
