### PR TITLE
docs: Update license copyright owner

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Kubeply
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update the Apache-2.0 license appendix boilerplate to use the repository copyright owner instead of the placeholder text.

This replaces `Copyright [yyyy] [name of copyright owner]` with `Copyright 2026 Kubeply`.
