### PR TITLE
fix(kubernetes): Harden service endpoints task

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -17,6 +17,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=rhysd/actionlint
   ACTIONLINT_VERSION: v1.7.12
+  # renovate: datasource=github-releases depName=oven-sh/bun
+  BUN_VERSION: 1.3.10
   # renovate: datasource=npm depName=@taplo/cli
   TAPLO_VERSION: 0.7.0
 
@@ -78,7 +80,9 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y jq nodejs npm shellcheck
+          sudo apt-get install -y jq shellcheck unzip
+          curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
+          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
       - name: Validate file formatting and lint
         run: ./scripts/lint-files.sh
@@ -91,5 +95,5 @@ jobs:
           set -euo pipefail
           uvx --from harbor harbor sync datasets/kubernetes-core
           uvx --from harbor harbor sync datasets/terraform-core
-          npx --yes "@taplo/cli@${TAPLO_VERSION}" fmt "**/*.toml" "!jobs/**"
+          bunx "@taplo/cli@${TAPLO_VERSION}" fmt "**/*.toml" "!jobs/**"
           git diff --exit-code -- datasets

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -13,7 +13,7 @@ email = "thomas@kubeply.com"
 
 [[tasks]]
 name = "kubeply/debug-service-endpoints"
-digest = "sha256:5e768bb5a1e91ae4a1b9da31cb82e89d34db54ff6508ba970c26834a3541a51e"
+digest = "sha256:a375ed8cfa19863097481c670e4abfc5f950305afd1becb235ec4ac892628f8c"
 
 [[tasks]]
 name = "kubeply/repair-readiness-probe-path"

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -13,7 +13,7 @@ email = "thomas@kubeply.com"
 
 [[tasks]]
 name = "kubeply/debug-service-endpoints"
-digest = "sha256:559d109c3116f1a753dc61091826def1fb920c92743e2e1519008cf98d9001d8"
+digest = "sha256:5e768bb5a1e91ae4a1b9da31cb82e89d34db54ff6508ba970c26834a3541a51e"
 
 
 [[files]]

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/Dockerfile
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/Dockerfile
@@ -12,6 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY workspace/ /app/
 COPY scripts/ /usr/local/bin/
 RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       bootstrap:
         condition: service_completed_successfully
     volumes:
-      - kubeconfig:/kube
+      - agent-kubeconfig:/kube:ro
 
   k3s:
     image: rancher/k3s:v1.30.6-k3s1
@@ -13,11 +13,11 @@ services:
       - server
       - --disable=traefik
       - --disable=servicelb
-      - --write-kubeconfig=/kube/kubeconfig.yaml
+      - --write-kubeconfig=/admin-kube/admin-kubeconfig.yaml
       - --write-kubeconfig-mode=666
       - --tls-san=k3s
     volumes:
-      - kubeconfig:/kube
+      - admin-kubeconfig:/admin-kube
       - k3s-data:/var/lib/rancher/k3s
     healthcheck:
       test: ["CMD-SHELL", "kubectl get --raw=/readyz >/dev/null 2>&1"]
@@ -33,11 +33,14 @@ services:
       k3s:
         condition: service_healthy
     environment:
-      KUBECONFIG: /kube/kubeconfig.yaml
+      KUBECONFIG: /admin-kube/admin-kubeconfig.yaml
     volumes:
-      - kubeconfig:/kube
+      - agent-kubeconfig:/kube
+      - admin-kubeconfig:/admin-kube
+      - ./workspace/bootstrap:/bootstrap:ro
     command: ["bootstrap-cluster"]
 
 volumes:
-  kubeconfig:
+  agent-kubeconfig:
+  admin-kubeconfig:
   k3s-data:

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/bootstrap-cluster
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 namespace="web-debug"
+agent_secret="infra-bench-agent-token"
 
 prepare-kubeconfig
 
-kubectl apply -f /app/bootstrap/web.yaml
+kubectl apply -f /bootstrap/web.yaml
 kubectl -n "$namespace" rollout status deployment/web --timeout=180s
 
 baseline_deployment_uid="$(
@@ -17,22 +18,68 @@ baseline_service_uid="$(
     -o jsonpath='{.data.service_uid}'
 )"
 
-if [[ -n "$baseline_deployment_uid" && -n "$baseline_service_uid" ]]; then
-  exit 0
+if [[ -z "$baseline_deployment_uid" || -z "$baseline_service_uid" ]]; then
+  deployment_uid="$(
+    kubectl -n "$namespace" get deployment web -o jsonpath='{.metadata.uid}'
+  )"
+  service_uid="$(
+    kubectl -n "$namespace" get service web -o jsonpath='{.metadata.uid}'
+  )"
+
+  if [[ -z "$deployment_uid" || -z "$service_uid" ]]; then
+    echo "failed to capture baseline resource UIDs" >&2
+    exit 1
+  fi
+
+  kubectl -n "$namespace" patch configmap infra-bench-baseline \
+    --type merge \
+    --patch "{\"data\":{\"deployment_uid\":\"${deployment_uid}\",\"service_uid\":\"${service_uid}\"}}"
 fi
 
-deployment_uid="$(
-  kubectl -n "$namespace" get deployment web -o jsonpath='{.metadata.uid}'
-)"
-service_uid="$(
-  kubectl -n "$namespace" get service web -o jsonpath='{.metadata.uid}'
-)"
+for _ in $(seq 1 60); do
+  token_data="$(
+    kubectl -n "$namespace" get secret "$agent_secret" \
+      -o jsonpath='{.data.token}' 2>/dev/null || true
+  )"
+  ca_data="$(
+    kubectl -n "$namespace" get secret "$agent_secret" \
+      -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true
+  )"
 
-if [[ -z "$deployment_uid" || -z "$service_uid" ]]; then
-  echo "failed to capture baseline resource UIDs" >&2
+  if [[ -n "$token_data" && -n "$ca_data" ]]; then
+    break
+  fi
+
+  sleep 1
+done
+
+if [[ -z "$token_data" || -z "$ca_data" ]]; then
+  echo "failed to prepare agent ServiceAccount token" >&2
   exit 1
 fi
 
-kubectl -n "$namespace" patch configmap infra-bench-baseline \
-  --type merge \
-  --patch "{\"data\":{\"deployment_uid\":\"${deployment_uid}\",\"service_uid\":\"${service_uid}\"}}"
+api_server="$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.server}')"
+agent_token="$(printf '%s' "$token_data" | base64 --decode)"
+
+mkdir -p /kube
+cat > /kube/kubeconfig.yaml <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: ${api_server}
+    certificate-authority-data: ${ca_data}
+users:
+- name: infra-bench-agent
+  user:
+    token: ${agent_token}
+contexts:
+- name: infra-bench-agent
+  context:
+    cluster: local
+    namespace: ${namespace}
+    user: infra-bench-agent
+current-context: infra-bench-agent
+EOF
+chmod 0444 /kube/kubeconfig.yaml

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/prepare-kubeconfig
@@ -15,10 +15,13 @@ if [[ ! -s "$kubeconfig" ]]; then
   exit 1
 fi
 
-sed -i 's#https://127.0.0.1:6443#https://k3s:6443#g' "$kubeconfig"
+if grep -q 'https://127.0.0.1:6443' "$kubeconfig"; then
+  sed -i 's#https://127.0.0.1:6443#https://k3s:6443#g' "$kubeconfig"
+fi
 
 for _ in $(seq 1 120); do
-  if kubectl get --raw=/readyz >/dev/null 2>&1; then
+  if kubectl get --raw=/readyz >/dev/null 2>&1 \
+    || kubectl -n web-debug get deployment web >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
@@ -25,7 +25,8 @@ metadata:
   namespace: web-debug
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "endpoints", "events", "pods", "pods/log", "services"]
+    resources:
+      ["configmaps", "endpoints", "events", "pods", "pods/log", "services"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
@@ -3,6 +3,54 @@ kind: Namespace
 metadata:
   name: web-debug
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: infra-bench-agent
+  namespace: web-debug
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: infra-bench-agent-token
+  namespace: web-debug
+  annotations:
+    kubernetes.io/service-account.name: infra-bench-agent
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: infra-bench-agent
+  namespace: web-debug
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "endpoints", "events", "pods", "pods/log", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "replicasets", "statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["cronjobs", "jobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: infra-bench-agent
+  namespace: web-debug
+subjects:
+  - kind: ServiceAccount
+    name: infra-bench-agent
+    namespace: web-debug
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: infra-bench-agent
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/datasets/kubernetes-core/debug-service-endpoints/tests/test_service_endpoints.sh
+++ b/datasets/kubernetes-core/debug-service-endpoints/tests/test_service_endpoints.sh
@@ -63,6 +63,21 @@ if [[ "$service_names" != "web" ]]; then
   exit 1
 fi
 
+unexpected_workloads="$(
+  {
+    kubectl -n "$namespace" get daemonsets.apps -o name
+    kubectl -n "$namespace" get statefulsets.apps -o name
+    kubectl -n "$namespace" get jobs.batch -o name
+    kubectl -n "$namespace" get cronjobs.batch -o name
+  } 2>/dev/null | sort
+)"
+
+if [[ -n "$unexpected_workloads" ]]; then
+  echo "Unexpected replacement workload resources in $namespace:" >&2
+  echo "$unexpected_workloads" >&2
+  exit 1
+fi
+
 deployment_labels="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.metadata.labels.app}')"
 service_selector="$(kubectl -n "$namespace" get service web -o jsonpath='{.spec.selector.app}')"
 container_names="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[*].name}')"
@@ -120,6 +135,30 @@ if [[ "$ready_pods" != "2" ]]; then
   echo "Expected 2 ready pods for app=web, got $ready_pods" >&2
   exit 1
 fi
+
+while IFS='|' read -r pod_name pod_app owner_kind; do
+  [[ -z "$pod_name" ]] && continue
+
+  if [[ "$pod_app" != "web" || "$owner_kind" != "ReplicaSet" ]]; then
+    echo "Unexpected pod ownership for ${pod_name}: app=${pod_app} ownerKind=${owner_kind}" >&2
+    exit 1
+  fi
+done < <(
+  kubectl -n "$namespace" get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.labels.app}{"|"}{.metadata.ownerReferences[0].kind}{"\n"}{end}'
+)
+
+while IFS='|' read -r replicaset_name owner_kind owner_name; do
+  [[ -z "$replicaset_name" ]] && continue
+
+  if [[ "$owner_kind" != "Deployment" || "$owner_name" != "web" ]]; then
+    echo "Unexpected ReplicaSet ownership for ${replicaset_name}: ownerKind=${owner_kind} ownerName=${owner_name}" >&2
+    exit 1
+  fi
+done < <(
+  kubectl -n "$namespace" get replicasets \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.ownerReferences[0].kind}{"|"}{.metadata.ownerReferences[0].name}{"\n"}{end}'
+)
 
 for _ in $(seq 1 60); do
   endpoint_ips="$(kubectl -n "$namespace" get endpoints web -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"

--- a/scripts/lint-files.sh
+++ b/scripts/lint-files.sh
@@ -20,7 +20,7 @@ collect_files() {
     "$@"
 }
 
-require_command npx
+require_command bunx
 require_command jq
 require_command shellcheck
 require_command uvx
@@ -37,8 +37,8 @@ while IFS= read -r -d "" path; do
   toml_files+=("$path")
 done < <(collect_files -type f -name "*.toml" -print0)
 if [[ "${#toml_files[@]}" -gt 0 ]]; then
-  npx --yes "@taplo/cli@${TAPLO_VERSION}" fmt --check "${toml_files[@]}"
-  npx --yes "@taplo/cli@${TAPLO_VERSION}" lint "${toml_files[@]}"
+  bunx "@taplo/cli@${TAPLO_VERSION}" fmt --check "${toml_files[@]}"
+  bunx "@taplo/cli@${TAPLO_VERSION}" lint "${toml_files[@]}"
 fi
 
 yaml_json_files=()
@@ -48,7 +48,7 @@ done < <(
   collect_files -type f \( -name "*.yaml" -o -name "*.yml" -o -name "*.json" \) -print0
 )
 if [[ "${#yaml_json_files[@]}" -gt 0 ]]; then
-  npx --yes "prettier@${PRETTIER_VERSION}" --check "${yaml_json_files[@]}"
+  bunx "prettier@${PRETTIER_VERSION}" --check "${yaml_json_files[@]}"
 fi
 
 json_files=()


### PR DESCRIPTION
Harden the existing `debug-service-endpoints` Kubernetes task against the same bypass classes found in the readiness probe task review.

The task now generates a restricted ServiceAccount kubeconfig for the agent while keeping admin credentials available only to bootstrap and verifier flows. Bootstrap manifests are mounted only into the bootstrap service instead of being copied into `/app`, so the starting-state YAML no longer exposes the selector mismatch directly to the agent.

The verifier now also rejects unexpected workload resource kinds and validates Pod and ReplicaSet ownership, making replacement-resource shortcuts fail explicitly.

Validated with shell syntax checks, repository structure validation, Harbor sync for `kubernetes-core` and `terraform-core`, and an oracle Harbor run for `debug-service-endpoints` with mean reward `1.000`.
