### PR TITLE
refactor(kubernetes): Split bootstrap task images

### DIFF
--- a/.agents/skills/design-infra-task/SKILL.md
+++ b/.agents/skills/design-infra-task/SKILL.md
@@ -56,6 +56,12 @@ Include these fields:
 - Required metadata, including `canary`
 - Validation commands
 
+For Kubernetes `local_cluster` task designs, specify the two-image environment
+shape: `environment/Dockerfile` for the agent, solution, and verifier runtime,
+and `environment/Dockerfile.bootstrap` for bootstrap-only setup code and
+fixtures. Bootstrap manifests and scripts must not be present in the agent
+image unless they are intentionally part of the task.
+
 ## Canary Requirement
 
 Every published task must include the same canary string in two places:

--- a/.agents/skills/implement-infra-task/SKILL.md
+++ b/.agents/skills/implement-infra-task/SKILL.md
@@ -88,8 +88,9 @@ Before editing files, restate the contract in a short plan:
      verification.
    - Keep task-specific bootstrap and verifier logic task-local unless several
      implemented tasks prove shared code is worth adding.
-   - For live-cluster tasks, do not copy bootstrap manifests that reveal the
-     answer into `/app`; mount them only into the bootstrap service.
+   - For live-cluster tasks, do not copy bootstrap scripts or bootstrap
+     manifests that reveal the answer into the agent image or `/app`; keep them
+     in the bootstrap image and bootstrap-only mounts.
 
 5. Write `instruction.md`.
    - State the working directory.
@@ -128,6 +129,9 @@ Local-cluster tasks should use separate cluster credentials:
   the intended fix.
 - Do not let the agent mutate verifier-trusted baseline data, such as a
   ConfigMap that stores original resource UIDs.
+- Use separate task-local images: `environment/Dockerfile` for the agent,
+  solution, and verifier runtime, and `environment/Dockerfile.bootstrap` for the
+  bootstrap service. Do not copy `bootstrap-cluster` into the agent image.
 
 The verifier should usually check:
 
@@ -148,6 +152,7 @@ Use the smallest local-cluster structure that fits the task:
 ```text
 environment/
 |-- Dockerfile
+|-- Dockerfile.bootstrap
 |-- docker-compose.yaml
 |-- scripts/
 |   |-- bootstrap-cluster
@@ -164,7 +169,7 @@ Run a bypass review before final validation:
 - Can the agent mutate verifier baseline data?
 - Can the agent delete and recreate the target resource and still pass?
 - Can the agent create alternate workloads, Services, or standalone Pods?
-- Can the agent read bootstrap assets that reveal the answer?
+- Can the agent read bootstrap scripts or assets that reveal the answer?
 - Does the verifier check ownership relationships, not just counts?
 
 For current k3s sidecar tasks, keep `allow_internet = true` unless an oracle run

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Dataset | 🟢 Easy | 🟡 Medium | 🔴 Hard | Status |
 | --- | ---: | ---: | ---: | --- |
-| [`kubeply/kubernetes-core`](datasets/kubernetes-core) | 1 | 0 | 0 | 🛠️ Working |
+| [`kubeply/kubernetes-core`](datasets/kubernetes-core) | 22 | 0 | 0 | 🛠️ Working |
 | [`kubeply/terraform-core`](datasets/terraform-core) | 0 | 0 | 0 | 🛠️ Working |
 | `kubeply/observability-core` | 0 | 0 | 0 | ⏳ Not started yet |
 

--- a/datasets/kubernetes-core/add-maintenance-toleration/environment/Dockerfile
+++ b/datasets/kubernetes-core/add-maintenance-toleration/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/add-maintenance-toleration/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/add-maintenance-toleration/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/add-maintenance-toleration/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/add-maintenance-toleration/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/add-rbac-list-verb/environment/Dockerfile
+++ b/datasets/kubernetes-core/add-rbac-list-verb/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/add-rbac-list-verb/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/add-rbac-list-verb/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/add-rbac-list-verb/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/add-rbac-list-verb/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/allow-api-network-policy/environment/Dockerfile
+++ b/datasets/kubernetes-core/allow-api-network-policy/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/allow-api-network-policy/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/allow-api-network-policy/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/allow-api-network-policy/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/allow-api-network-policy/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -13,91 +13,91 @@ email = "thomas@kubeply.com"
 
 [[tasks]]
 name = "kubeply/debug-service-endpoints"
-digest = "sha256:4454da50bd9ebfb8feb92bc6a76dc9ecd1ee909ef54d5b036ddbe78c520899be"
+digest = "sha256:e02e828fb483f459854a4b64084fb31fdcc2f47de1c9c311e5fbe16c5ab89a30"
 
 [[tasks]]
 name = "kubeply/repair-readiness-probe-path"
-digest = "sha256:5e2b584afe34d91997c5c79048d2c29a79b1d76f269e31768d00bfaf0151df6b"
+digest = "sha256:1c770aac9dde7f65ecadc2f4581f7c10a149948cc38414a07084c51a0660dca1"
 
 [[tasks]]
 name = "kubeply/fix-config-key-reference"
-digest = "sha256:750f4a0ebf167fbf3da93ab3762f378253c31b36cbbb97a584805d2fd4e4a836"
+digest = "sha256:37de4cdff7fb947fe6061bfd18d6e51028ab4485f9f711b5e99e2617637dbd1e"
 
 [[tasks]]
 name = "kubeply/add-rbac-list-verb"
-digest = "sha256:07b2565c5a52b5d76ff93b05f56efa02ff6aabbb90cb136fc415105de19b97f6"
+digest = "sha256:11a6274a0f74837f28d7db6b0ef7f23bb5c569ea1df3499497ca65fdd612dbbc"
 
 [[tasks]]
 name = "kubeply/fix-node-selector-mismatch"
-digest = "sha256:72feffcbad96c9f0a2855d0e6dd35281f1455941b5ccdc582af7cc8b9a2bbb86"
+digest = "sha256:66acc2d2a504ccaa78c5390fb1ef635c0bc647457ff14959757fcc0c437d39cf"
 
 [[tasks]]
 name = "kubeply/rightsize-cpu-request"
-digest = "sha256:237a22bbd6af5a96505184fb6e05ed4be140c6809df2e43e9ae82fd380dd9f7d"
+digest = "sha256:2f9a76704667c75df2c60ec316464a59422eb70b19f4bc6413b6be819c8820f2"
 
 [[tasks]]
 name = "kubeply/target-gpu-node-label"
-digest = "sha256:ca253e6343a95cfad49a896382107ef32a3c9010fc053002da0355524479612c"
+digest = "sha256:8e86b52bc36decf6505e783640c21eb53c620c489157667a0f391be77807b82a"
 
 [[tasks]]
 name = "kubeply/fix-pvc-mount-claim"
-digest = "sha256:a762cbddbefd86f346b3a080f0904fc608a903a445b63a490cd3fd78e425d1d9"
+digest = "sha256:eb0953b533f0358e6b6ee0b813f08dd13d16057fa4809fe69199dfebb60ae50f"
 
 [[tasks]]
 name = "kubeply/allow-api-network-policy"
-digest = "sha256:0a8c0875f58c061263bbb32f387975fdb5c833e8a0ccfd61b491599af60275dc"
+digest = "sha256:7d39d5d8a682743ef5e5546b29966fdab352f1c53d496c3119bdce97aab05b50"
 
 [[tasks]]
 name = "kubeply/reconnect-frontend-api"
-digest = "sha256:bde1664bd450e1a6d0d45a8cbe5adad95edcc83cb0eed2f019fa82ad172cf72e"
+digest = "sha256:15194a10caf9a120f598b33218331aab85753356f979667cf3ed1a22652806fa"
 
 [[tasks]]
 name = "kubeply/fix-restricted-security-context"
-digest = "sha256:13914fc4b5b30c6ef28c638e4c481ad51a1e5fdef6de74e0a580d37d297f79cb"
+digest = "sha256:9056620af630b79c28b367f991de19152631ff7ae862f68b42973d8b0ca6e33b"
 
 [[tasks]]
 name = "kubeply/fix-crashloop-env-var"
-digest = "sha256:5b2887f95238c71976bf6338061a34bfeccc869068797b155eaead0103da86b1"
+digest = "sha256:13bc3e0bb80c9ecfb5b8ad0d3006e759d616863e88f548e0748c8de3ab825314"
 
 [[tasks]]
 name = "kubeply/fix-service-dns-name"
-digest = "sha256:aaf92abb9ada41bdeec33e6eab818c9e1687c4a5c0ab94b25e925804db82217d"
+digest = "sha256:2ee03fef01302bee66907a75a65069de512ed15cb1021f214f563de26fdcdf23"
 
 [[tasks]]
 name = "kubeply/fix-job-command-argument"
-digest = "sha256:149dad0eaa76c83b0cec0a1132b02cf7d0ddd11802c0a02c22a6ceae2390c951"
+digest = "sha256:2ee0a8a720a05d5be84bed0e18d6515fcb7cbccd3093bc63401593f985f08d81"
 
 [[tasks]]
 name = "kubeply/fix-quirky-health-endpoint"
-digest = "sha256:1ed90424cd5cf1617143751d0a5ac61c46a5259ad671de914bd7376566de9f03"
+digest = "sha256:8836a9785636ce9186481a46a149572dc2fad203812b2bd9788ae20282d7012f"
 
 [[tasks]]
 name = "kubeply/repair-ingress-backend-port"
-digest = "sha256:f45c4a1b163fa9881cec804fefc5777b897792ebdf8734192cc0107c48b0e3dc"
+digest = "sha256:c9f0632cc679a3e360a02d131e681080d96a927cc61a36281d3384959a14b666"
 
 [[tasks]]
 name = "kubeply/fix-hpa-scale-target"
-digest = "sha256:698753cb65f257973e556bceb8047739be5d97d5f73bd6f9bf30cc753e60b8ea"
+digest = "sha256:812d077c3522c49c6a62668e19b39d2e215388af2457570721777b156fcc944c"
 
 [[tasks]]
 name = "kubeply/fix-controller-service-selector"
-digest = "sha256:6472791efe142f0f0fb5fe7ac1a1f06e2ba93b099088d75874b2ae1fe930b84d"
+digest = "sha256:4a407e8a45ebdf090eb4bfb7398d8fad5fea1c1d6e11842bed5e1074093bc9b4"
 
 [[tasks]]
 name = "kubeply/restore-missing-configmap"
-digest = "sha256:be2ea9a81c43f8ac2779e89f0340fa5a30a5c4ba416e193ae7dd7cbbf9a57319"
+digest = "sha256:3604a02aa147f634c606962fb0cc63ebb311b4503c76bf37dcf19b1df1690616"
 
 [[tasks]]
 name = "kubeply/replace-deprecated-ingress-api"
-digest = "sha256:f4acd1b055e07ecdddd0b66f8d44ae463be1d0850444d4ac8bdc2cab4107f85e"
+digest = "sha256:772e872ac341a63db23ea3d90dbe6ddc0e39e3f2bc2c126a412e75f0846858fb"
 
 [[tasks]]
 name = "kubeply/add-maintenance-toleration"
-digest = "sha256:bf5e9942ce0a4b542c5f395694762b5de044edc3e1790ef8483f0886135f24e5"
+digest = "sha256:b99f0e62f6004c4018d72e2dd94a93a26199ef89d2464694b7c4b5e0661034da"
 
 [[tasks]]
 name = "kubeply/fix-simple-cr-field"
-digest = "sha256:9516144bdfcbb532be0397be196cde7bd6dfe9e220c88912ee5500d06975780e"
+digest = "sha256:ecc37de7bde7fe9be3e5c7fc79beafd08c9b0ead3d72e7ce84bea4e9f24c9292"
 
 
 [[files]]

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/Dockerfile
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-controller-service-selector/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-controller-service-selector/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-controller-service-selector/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-controller-service-selector/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-controller-service-selector/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-controller-service-selector/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-crashloop-env-var/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-crashloop-env-var/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-crashloop-env-var/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-hpa-scale-target/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-hpa-scale-target/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-hpa-scale-target/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-job-command-argument/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-job-command-argument/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-job-command-argument/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-job-command-argument/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-job-command-argument/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-job-command-argument/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-restricted-security-context/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-restricted-security-context/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-restricted-security-context/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-restricted-security-context/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-restricted-security-context/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-restricted-security-context/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-service-dns-name/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-service-dns-name/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-service-dns-name/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-service-dns-name/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-service-dns-name/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-service-dns-name/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/Dockerfile
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/reconnect-frontend-api/environment/Dockerfile
+++ b/datasets/kubernetes-core/reconnect-frontend-api/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/reconnect-frontend-api/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/reconnect-frontend-api/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/reconnect-frontend-api/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/reconnect-frontend-api/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/repair-ingress-backend-port/environment/Dockerfile
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/repair-ingress-backend-port/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/repair-ingress-backend-port/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/environment/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/Dockerfile
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/Dockerfile
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/Dockerfile
@@ -13,5 +13,5 @@ ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
 COPY workspace/app/ /app/
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/Dockerfile.bootstrap
@@ -1,0 +1,17 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY workspace/app/ /app/
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/restore-missing-configmap/environment/Dockerfile
+++ b/datasets/kubernetes-core/restore-missing-configmap/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/restore-missing-configmap/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/restore-missing-configmap/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/restore-missing-configmap/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/restore-missing-configmap/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/rightsize-cpu-request/environment/Dockerfile
+++ b/datasets/kubernetes-core/rightsize-cpu-request/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/rightsize-cpu-request/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/rightsize-cpu-request/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/rightsize-cpu-request/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/rightsize-cpu-request/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/datasets/kubernetes-core/target-gpu-node-label/environment/Dockerfile
+++ b/datasets/kubernetes-core/target-gpu-node-label/environment/Dockerfile
@@ -12,5 +12,5 @@ RUN apt-get update \
 ENV KUBECONFIG=/kube/kubeconfig.yaml
 
 WORKDIR /app
-COPY scripts/ /usr/local/bin/
-RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/datasets/kubernetes-core/target-gpu-node-label/environment/Dockerfile.bootstrap
+++ b/datasets/kubernetes-core/target-gpu-node-label/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/datasets/kubernetes-core/target-gpu-node-label/environment/docker-compose.yaml
+++ b/datasets/kubernetes-core/target-gpu-node-label/environment/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
   bootstrap:
     build:
       context: .
+      dockerfile: Dockerfile.bootstrap
     depends_on:
       k3s:
         condition: service_healthy

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -77,6 +77,9 @@ Do not reveal verifier internals or exact assertions.
 - Keep the Docker build context minimal.
 - Do not copy tests, solutions, or hidden answers into the environment image.
 - Prefer deterministic local assets over network calls at verification time.
+- For local-cluster tasks, separate the agent, solution, and verifier runtime
+  image from the bootstrap image so bootstrap scripts and answer-bearing setup
+  assets are not present in the agent container.
 
 ## Verification
 

--- a/docs/harbor.md
+++ b/docs/harbor.md
@@ -140,6 +140,13 @@ container to reach the cluster API. When using that exception, keep external
 dependencies out of the task and rely on restricted cluster credentials to
 reduce the shortcut surface.
 
+Docker Compose local-cluster tasks should use separate images for the agent
+runtime and bootstrap runtime. The default `environment/Dockerfile` is the
+agent, solution, and verifier image and must not include `bootstrap-cluster` or
+answer-bearing setup assets. Bootstrap services should build from a
+bootstrap-specific Dockerfile, such as `environment/Dockerfile.bootstrap`, and
+may mount `environment/workspace/bootstrap` read-only.
+
 Healthchecks are optional and should be used only when the task environment
 starts a service that must become ready before the agent begins:
 

--- a/docs/task-design.md
+++ b/docs/task-design.md
@@ -25,7 +25,10 @@ Document the class in `task.toml` metadata.
 Place all starting files under `environment/`. The agent should only need files
 available in the runtime environment.
 
-For Docker environments, the Dockerfile should copy starting assets into `/app`.
+For Docker environments, the agent `Dockerfile` should copy only the files the
+agent is meant to see into `/app`. For local-cluster Kubernetes tasks, keep
+bootstrap-only assets and scripts out of the agent image; expose them through a
+separate bootstrap image or bootstrap-only mounts.
 
 ## 4. Generate the Canary
 

--- a/docs/task-rules/kubernetes.md
+++ b/docs/task-rules/kubernetes.md
@@ -94,6 +94,7 @@ For Kubernetes tasks that use a local cluster, prefer this structure:
 ```text
 environment/
 |-- Dockerfile
+|-- Dockerfile.bootstrap
 |-- docker-compose.yaml
 |-- scripts/
 |   |-- bootstrap-cluster
@@ -111,8 +112,16 @@ Use `bootstrap-cluster` to:
   and Service UIDs. If those facts are stored in Kubernetes resources, the agent
   must not be able to mutate those resources.
 
-Use `prepare-kubeconfig` from the agent, solution, and verifier when the
-cluster writes a kubeconfig with container-local addresses. Keep that helper
+Use separate task-local images for local-cluster work:
+
+- `environment/Dockerfile` is the agent, solution, and verifier runtime. It
+  should include `kubectl`, `prepare-kubeconfig`, and only files intentionally
+  exposed to the agent.
+- `environment/Dockerfile.bootstrap` is the bootstrap runtime. It may include
+  `bootstrap-cluster` and any setup-only helpers needed to prepare the cluster.
+
+Use `prepare-kubeconfig` from the agent, solution, verifier, and bootstrap when
+the cluster writes a kubeconfig with container-local addresses. Keep that helper
 small and task-local until multiple Kubernetes tasks prove a shared helper is
 worth maintaining.
 
@@ -128,8 +137,11 @@ authority.
   needed for the intended fix.
 - Do not let the agent update verifier-trusted baseline objects, such as
   ConfigMaps that store original resource UIDs.
+- Do not copy `bootstrap-cluster` into the agent runtime image. The bootstrap
+  service should build from `Dockerfile.bootstrap` or otherwise receive
+  bootstrap-only code outside the agent container.
 
-Do not copy answer-bearing bootstrap assets into `/app`. If
+Do not copy answer-bearing bootstrap assets into `/app` or the agent image. If
 `environment/workspace/bootstrap/*.yaml` reveals the broken field or intended
 fix, mount it only into the bootstrap service, for example at `/bootstrap:ro`.
 The agent workspace should contain only files the task intentionally exposes.

--- a/scripts/validate-structure.sh
+++ b/scripts/validate-structure.sh
@@ -19,6 +19,16 @@ while IFS= read -r task_toml; do
 
   [[ -f "$task_dir/instruction.md" ]] || fail "$task_dir missing instruction.md"
   [[ -d "$task_dir/environment" ]] || fail "$task_dir missing environment/"
+  if [[ -f "$task_dir/environment/scripts/bootstrap-cluster" ]]; then
+    [[ -f "$task_dir/environment/Dockerfile" ]] || fail "$task_dir missing environment/Dockerfile"
+    [[ -f "$task_dir/environment/Dockerfile.bootstrap" ]] || fail "$task_dir missing environment/Dockerfile.bootstrap"
+    [[ -f "$task_dir/environment/docker-compose.yaml" ]] || fail "$task_dir missing environment/docker-compose.yaml"
+    if grep -q 'bootstrap-cluster' "$task_dir/environment/Dockerfile"; then
+      fail "$task_dir agent Dockerfile must not copy bootstrap-cluster"
+    fi
+    grep -q 'Dockerfile.bootstrap' "$task_dir/environment/docker-compose.yaml" \
+      || fail "$task_dir bootstrap service must build from Dockerfile.bootstrap"
+  fi
   [[ -f "$task_dir/solution/solve.sh" ]] || fail "$task_dir missing solution/solve.sh"
   [[ -x "$task_dir/solution/solve.sh" ]] || fail "$task_dir solution/solve.sh is not executable"
   [[ -f "$task_dir/tests/test.sh" ]] || fail "$task_dir missing tests/test.sh"


### PR DESCRIPTION
Split Kubernetes local-cluster tasks into separate agent and bootstrap image definitions.

The default task Dockerfile is now the agent, solution, and verifier runtime and only carries `prepare-kubeconfig`. Each easy Kubernetes task now has a `Dockerfile.bootstrap`, and the bootstrap service explicitly builds from it so `bootstrap-cluster` is no longer present in the agent container.

This records the two-image local-cluster convention in the Kubernetes docs, general task design guidance, Harbor notes, and infra task skills. The structure validator now enforces that any task with `environment/scripts/bootstrap-cluster` uses `Dockerfile.bootstrap` and keeps `bootstrap-cluster` out of the agent Dockerfile.

The Kubernetes README count now reflects the 22 implemented easy tasks, and the Kubernetes dataset digests were refreshed after the task environment changes.

Validation completed:

- `bash -n scripts/validate-structure.sh datasets/kubernetes-core/*/environment/scripts/* datasets/kubernetes-core/*/tests/*.sh datasets/kubernetes-core/*/solution/solve.sh`
- `./scripts/validate-structure.sh`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/terraform-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core -a oracle` passed 22/22 with mean reward 1.000 and 0 exceptions.