### PR TITLE
chore(kubernetes): Harden medium task readiness

### DIFF
--- a/.agents/skills/design-infra-task/SKILL.md
+++ b/.agents/skills/design-infra-task/SKILL.md
@@ -62,6 +62,13 @@ and `environment/Dockerfile.bootstrap` for bootstrap-only setup code and
 fixtures. Bootstrap manifests and scripts must not be present in the agent
 image unless they are intentionally part of the task.
 
+For Kubernetes medium task designs, require a bounded diagnosis across at least
+two related Kubernetes concepts, such as workload plus Service, ConfigMap,
+Secret, RBAC, NetworkPolicy, storage, Job, or controller-generated state. Keep
+the outcome focused on one operator goal and identify the shortcut fixes the
+verifier must reject. Use `docs/templates/kubernetes-local-cluster-task/` as the
+starting environment shape for live-cluster medium and hard tasks.
+
 ## Canary Requirement
 
 Every published task must include the same canary string in two places:
@@ -83,6 +90,7 @@ For a designed task, list the checks that must pass once implemented:
 
 ```bash
 ./scripts/validate-structure.sh
+python3 scripts/lint-kubernetes-rbac.py
 uvx --from harbor harbor sync datasets/<dataset-name>
 uvx --from harbor harbor run -p datasets/<dataset-name>/<task-name> -a oracle
 ```

--- a/.agents/skills/implement-infra-task/SKILL.md
+++ b/.agents/skills/implement-infra-task/SKILL.md
@@ -28,9 +28,10 @@ question before editing files.
    - `docs/task-rules/<domain>.md`
 3. Inspect existing tasks in `datasets/<dataset-name>/`, especially tasks with
    the same difficulty or environment class.
-4. For Kubernetes Core v1 easy tasks, inspect
-   `datasets/kubernetes-core/debug-service-endpoints` as the current local
-   cluster reference pattern.
+4. For Kubernetes Core live-cluster tasks, inspect
+   `docs/templates/kubernetes-local-cluster-task/` and
+   `datasets/kubernetes-core/debug-service-endpoints` as the current two-image
+   local-cluster reference pattern.
 
 Derive `<domain>` from the dataset name:
 
@@ -114,11 +115,19 @@ Before editing files, restate the contract in a short plan:
 9. Update the GitHub issue or PR with the actual validation results. Do not
    mark the issue complete until oracle validation passes.
 
-## Kubernetes Core v1 Easy Rules
+## Kubernetes Core v1 Rules
 
 For easy Kubernetes tasks, prefer `local_cluster` unless the issue explicitly
 requires otherwise. The task should prove a live `kubectl` diagnosis of one
 clear broken relationship.
+
+For medium Kubernetes tasks, preserve the same local-cluster isolation pattern
+and raise complexity through diagnosis, not hidden answers. A medium task should
+usually require correlating at least two related Kubernetes concepts, such as a
+workload plus Service, ConfigMap, Secret, RBAC, NetworkPolicy, storage, Job, or
+controller-generated resource. Keep the intended outcome bounded to one operator
+goal, and document which shortcut fixes the verifier rejects before tuning the
+oracle solution.
 
 Local-cluster tasks should use separate cluster credentials:
 
@@ -198,6 +207,7 @@ bash -n datasets/<dataset-name>/<task-name>/environment/scripts/*
 bash -n datasets/<dataset-name>/<task-name>/tests/*.sh
 bash -n datasets/<dataset-name>/<task-name>/solution/solve.sh
 ./scripts/validate-structure.sh
+python3 scripts/lint-kubernetes-rbac.py
 uvx --from harbor harbor sync datasets/<dataset-name>
 uvx --from harbor harbor run -p datasets/<dataset-name>/<task-name> -a oracle
 ```

--- a/.github/workflows/oracle-validation.yaml
+++ b/.github/workflows/oracle-validation.yaml
@@ -3,8 +3,12 @@ name: oracle-validation
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "17 2 * * *"
+    inputs:
+      run_oracle:
+        description: "Run the heavy Kubernetes Core oracle sweep"
+        required: true
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -15,6 +19,7 @@ concurrency:
 
 jobs:
   kubernetes-core-oracle:
+    if: ${{ inputs.run_oracle }}
     runs-on:
       group: kubeply-low-latency
       labels: kubeply-arm64-low-latency

--- a/.github/workflows/oracle-validation.yaml
+++ b/.github/workflows/oracle-validation.yaml
@@ -1,0 +1,30 @@
+---
+name: oracle-validation
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 2 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: oracle-validation-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  kubernetes-core-oracle:
+    runs-on:
+      group: kubeply-low-latency
+      labels: kubeply-arm64-low-latency
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          # renovate: datasource=pypi depName=uv
+          version: 0.11.7
+
+      - name: Run Kubernetes Core oracle sweep
+        run: uvx --from harbor harbor run -p datasets/kubernetes-core -a oracle

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -87,8 +87,19 @@ jobs:
       - name: Validate file formatting and lint
         run: ./scripts/lint-files.sh
 
+      - name: Validate task shell syntax
+        run: |
+          set -euo pipefail
+          bash -n scripts/validate-structure.sh \
+            datasets/kubernetes-core/*/environment/scripts/* \
+            datasets/kubernetes-core/*/tests/*.sh \
+            datasets/kubernetes-core/*/solution/solve.sh
+
       - name: Validate repository structure
         run: ./scripts/validate-structure.sh
+
+      - name: Lint Kubernetes agent RBAC
+        run: python3 scripts/lint-kubernetes-rbac.py
 
       - name: Verify dataset manifests are synchronized
         run: |
@@ -96,4 +107,4 @@ jobs:
           uvx --from harbor harbor sync datasets/kubernetes-core
           uvx --from harbor harbor sync datasets/terraform-core
           bunx "@taplo/cli@${TAPLO_VERSION}" fmt "**/*.toml" "!jobs/**"
-          git diff --exit-code -- datasets
+          git diff --exit-code

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -13,15 +13,15 @@ email = "thomas@kubeply.com"
 
 [[tasks]]
 name = "kubeply/debug-service-endpoints"
-digest = "sha256:e02e828fb483f459854a4b64084fb31fdcc2f47de1c9c311e5fbe16c5ab89a30"
+digest = "sha256:ad2522db0bc6e92192e36cd9d5e64e94040a25a79f45561e68e72e57aa7f91df"
 
 [[tasks]]
 name = "kubeply/repair-readiness-probe-path"
-digest = "sha256:1c770aac9dde7f65ecadc2f4581f7c10a149948cc38414a07084c51a0660dca1"
+digest = "sha256:391b7bf3bf75fb5e524e2524286e032c8ccf2cf53b62ec08c1008a7decccc0dc"
 
 [[tasks]]
 name = "kubeply/fix-config-key-reference"
-digest = "sha256:37de4cdff7fb947fe6061bfd18d6e51028ab4485f9f711b5e99e2617637dbd1e"
+digest = "sha256:e51141f46ae57aed0f23eb05e401814bf4c7518851443cd6aab69badf0a83716"
 
 [[tasks]]
 name = "kubeply/add-rbac-list-verb"

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
@@ -36,6 +36,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["services"]
+    resourceNames: ["web"]
     verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/workspace/bootstrap/config.yaml
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/workspace/bootstrap/config.yaml
@@ -46,6 +46,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
+    resourceNames: ["orders-api"]
     verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/workspace/bootstrap/readiness.yaml
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/workspace/bootstrap/readiness.yaml
@@ -44,6 +44,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
+    resourceNames: ["checkout-api"]
     verbs: ["patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/docs/task-rules/kubernetes.md
+++ b/docs/task-rules/kubernetes.md
@@ -25,6 +25,29 @@ Kubernetes is the first benchmark domain for `infra-bench`.
   topology constraints.
 - Storage: fix PVC, volume, and mount issues.
 
+## Difficulty Progression
+
+Use difficulty to describe Kubernetes operator complexity and bypass resistance,
+not the number of files touched.
+
+- `easy`: one broken relationship, one primary resource family, and direct
+  symptoms. The intended fix should be reachable after a short `kubectl`
+  inspection, and the verifier should still reject delete-and-recreate or
+  alternate-resource shortcuts.
+- `medium`: two or more related Kubernetes concepts, a moderate diagnosis path,
+  or symptoms that require correlating resources. Good medium tasks may combine
+  a workload with a Service, ConfigMap, Secret, RBAC rule, NetworkPolicy,
+  storage object, Job, or controller-generated resource. The fix should still
+  be bounded to one operator outcome and should not require guessing hidden
+  verifier details.
+- `hard`: layered or ambiguous failure modes, multi-step remediation, scarce
+  capacity, migration or upgrade constraints, or validation that spans several
+  controllers and runtime behaviors.
+
+For medium and hard `local_cluster` tasks, start from the same two-image
+environment pattern used by the easy tasks. Do not reintroduce a single image
+that copies bootstrap-only scripts or manifests into the agent runtime.
+
 ## Coverage Area Keywords
 
 Kubernetes tasks should include one primary coverage-area keyword in
@@ -102,6 +125,10 @@ environment/
 `-- workspace/
     `-- <starting-assets>
 ```
+
+A copyable skeleton lives in
+`docs/templates/kubernetes-local-cluster-task/`. Replace every `TODO_*`
+placeholder before moving it into `datasets/kubernetes-core/<task-name>`.
 
 Use `bootstrap-cluster` to:
 
@@ -207,6 +234,7 @@ Before adding a Kubernetes task to the dataset, run it in this order:
 
    ```bash
    ./scripts/validate-structure.sh
+   python3 scripts/lint-kubernetes-rbac.py
    uvx --from harbor harbor sync datasets/kubernetes-core
    ```
 

--- a/docs/templates/kubernetes-local-cluster-task/README.md
+++ b/docs/templates/kubernetes-local-cluster-task/README.md
@@ -1,0 +1,17 @@
+# Kubernetes Local Cluster Task Template
+
+Use this skeleton for Kubernetes tasks where the agent must repair live cluster
+state through `kubectl`.
+
+The template follows the two-image convention:
+
+- `environment/Dockerfile` is the agent, solution, and verifier runtime.
+- `environment/Dockerfile.bootstrap` is the bootstrap runtime.
+- `environment/scripts/bootstrap-cluster` and `environment/workspace/bootstrap`
+  are available only to the bootstrap service.
+- `environment/scripts/prepare-kubeconfig` is available to agent, solution,
+  verifier, and bootstrap.
+
+Before copying this template into `datasets/kubernetes-core/<task-name>`,
+replace all `TODO_*` placeholders, generate a fresh canary, and run the
+validation workflow documented in `docs/task-rules/kubernetes.md`.

--- a/docs/templates/kubernetes-local-cluster-task/environment/Dockerfile
+++ b/docs/templates/kubernetes-local-cluster-task/environment/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/prepare-kubeconfig /usr/local/bin/prepare-kubeconfig
+RUN chmod +x /usr/local/bin/prepare-kubeconfig

--- a/docs/templates/kubernetes-local-cluster-task/environment/Dockerfile.bootstrap
+++ b/docs/templates/kubernetes-local-cluster-task/environment/Dockerfile.bootstrap
@@ -1,0 +1,16 @@
+FROM debian:bookworm-slim
+
+ARG KUBECTL_VERSION=v1.30.6
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl \
+  && arch="$(dpkg --print-architecture)" \
+  && curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${arch}/kubectl" \
+  && chmod +x /usr/local/bin/kubectl \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV KUBECONFIG=/kube/kubeconfig.yaml
+
+WORKDIR /app
+COPY scripts/ /usr/local/bin/
+RUN chmod +x /usr/local/bin/prepare-kubeconfig /usr/local/bin/bootstrap-cluster

--- a/docs/templates/kubernetes-local-cluster-task/environment/docker-compose.yaml
+++ b/docs/templates/kubernetes-local-cluster-task/environment/docker-compose.yaml
@@ -1,0 +1,47 @@
+services:
+  main:
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    volumes:
+      - agent-kubeconfig:/kube:ro
+
+  k3s:
+    image: rancher/k3s:v1.30.6-k3s1
+    privileged: true
+    command:
+      - server
+      - --disable=traefik
+      - --disable=servicelb
+      - --write-kubeconfig=/admin-kube/admin-kubeconfig.yaml
+      - --write-kubeconfig-mode=666
+      - --tls-san=k3s
+    volumes:
+      - admin-kubeconfig:/admin-kube
+      - k3s-data:/var/lib/rancher/k3s
+    healthcheck:
+      test: ["CMD-SHELL", "kubectl get --raw=/readyz >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 10s
+      retries: 30
+      start_period: 20s
+
+  bootstrap:
+    build:
+      context: .
+      dockerfile: Dockerfile.bootstrap
+    depends_on:
+      k3s:
+        condition: service_healthy
+    environment:
+      KUBECONFIG: /admin-kube/admin-kubeconfig.yaml
+    volumes:
+      - agent-kubeconfig:/kube
+      - admin-kubeconfig:/admin-kube
+      - ./workspace/bootstrap:/bootstrap:ro
+    command: ["bootstrap-cluster"]
+
+volumes:
+  agent-kubeconfig:
+  admin-kubeconfig:
+  k3s-data:

--- a/docs/templates/kubernetes-local-cluster-task/environment/scripts/bootstrap-cluster
+++ b/docs/templates/kubernetes-local-cluster-task/environment/scripts/bootstrap-cluster
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+namespace="TODO_NAMESPACE"
+agent_secret="infra-bench-agent-token"
+
+prepare-kubeconfig
+
+kubectl apply -f /bootstrap/app.yaml
+
+# TODO: wait for the intended broken starting state and fail if it is absent.
+# TODO: record trusted baseline UIDs in an agent-read-only ConfigMap.
+
+for _ in $(seq 1 60); do
+  token_data="$(
+    kubectl -n "$namespace" get secret "$agent_secret" \
+      -o jsonpath='{.data.token}' 2>/dev/null || true
+  )"
+  ca_data="$(
+    kubectl -n "$namespace" get secret "$agent_secret" \
+      -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true
+  )"
+
+  if [[ -n "$token_data" && -n "$ca_data" ]]; then
+    break
+  fi
+
+  sleep 1
+done
+
+if [[ -z "${token_data:-}" || -z "${ca_data:-}" ]]; then
+  echo "failed to prepare agent ServiceAccount token" >&2
+  exit 1
+fi
+
+api_server="$(kubectl config view --raw -o jsonpath='{.clusters[0].cluster.server}')"
+agent_token="$(printf '%s' "$token_data" | base64 --decode)"
+
+mkdir -p /kube
+cat > /kube/kubeconfig.yaml <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: local
+  cluster:
+    server: ${api_server}
+    certificate-authority-data: ${ca_data}
+users:
+- name: infra-bench-agent
+  user:
+    token: ${agent_token}
+contexts:
+- name: infra-bench-agent
+  context:
+    cluster: local
+    namespace: ${namespace}
+    user: infra-bench-agent
+current-context: infra-bench-agent
+EOF
+chmod 0444 /kube/kubeconfig.yaml

--- a/docs/templates/kubernetes-local-cluster-task/environment/scripts/prepare-kubeconfig
+++ b/docs/templates/kubernetes-local-cluster-task/environment/scripts/prepare-kubeconfig
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f "${KUBECONFIG}" ]]; then
+  echo "KUBECONFIG ${KUBECONFIG} does not exist" >&2
+  exit 1
+fi
+
+kubectl config set-cluster local --server=https://k3s:6443 >/dev/null 2>&1 || true

--- a/docs/templates/kubernetes-local-cluster-task/environment/workspace/bootstrap/app.yaml
+++ b/docs/templates/kubernetes-local-cluster-task/environment/workspace/bootstrap/app.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: TODO_NAMESPACE
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: infra-bench-agent
+  namespace: TODO_NAMESPACE
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: infra-bench-agent-token
+  namespace: TODO_NAMESPACE
+  annotations:
+    kubernetes.io/service-account.name: infra-bench-agent
+type: kubernetes.io/service-account-token
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: infra-bench-agent
+  namespace: TODO_NAMESPACE
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps", "events", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    resourceNames: ["TODO_DEPLOYMENT"]
+    verbs: ["patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: infra-bench-agent
+  namespace: TODO_NAMESPACE
+subjects:
+  - kind: ServiceAccount
+    name: infra-bench-agent
+    namespace: TODO_NAMESPACE
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: infra-bench-agent
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: infra-bench-baseline
+  namespace: TODO_NAMESPACE
+data:
+  deployment_uid: ""

--- a/docs/templates/kubernetes-local-cluster-task/instruction.md
+++ b/docs/templates/kubernetes-local-cluster-task/instruction.md
@@ -1,0 +1,18 @@
+<infra-bench-canary: TODO_UUID>
+
+You are working in `/app`; the problem to fix is in the live Kubernetes
+cluster.
+
+A Kubernetes cluster is already running and `kubectl` is configured through
+`KUBECONFIG`.
+
+TODO_DESCRIBE_THE_OPERATOR_PROBLEM.
+
+Constraints:
+
+- Use `kubectl` to inspect the live resources before changing anything.
+- Preserve TODO_IDENTITY_AND_INVARIANTS.
+- Do not create replacement workloads or bypass resources.
+- Do not patch status or write verifier artifacts directly.
+
+Success means TODO_DESCRIBE_LIVE_SUCCESS_STATE.

--- a/docs/templates/kubernetes-local-cluster-task/solution/solve.sh
+++ b/docs/templates/kubernetes-local-cluster-task/solution/solve.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prepare-kubeconfig
+
+namespace="TODO_NAMESPACE"
+
+# TODO: implement the minimal oracle repair.
+kubectl -n "$namespace" get all

--- a/docs/templates/kubernetes-local-cluster-task/task.toml
+++ b/docs/templates/kubernetes-local-cluster-task/task.toml
@@ -1,0 +1,44 @@
+schema_version = "1.1"
+
+[task]
+name = "kubeply/TODO_TASK_NAME"
+description = "TODO_SHORT_DESCRIPTION"
+category = "kubernetes"
+keywords = ["kubernetes", "TODO_AREA_KEYWORD", "kubectl"]
+
+[[task.authors]]
+name = "Kubeply"
+email = "thomas@kubeply.com"
+
+[metadata]
+canary = "<infra-bench-canary: TODO_UUID>"
+difficulty = "medium"
+difficulty_explanation = "TODO_EXPLAIN_DIFFICULTY"
+expert_time_estimate_min = 15.0
+junior_time_estimate_min = 45.0
+scenario_type = "live_cluster_debug"
+requires_cluster = true
+kubernetes_focus = "TODO_FOCUS"
+
+[verifier]
+timeout_sec = 600.0
+
+[agent]
+timeout_sec = 600.0
+
+[environment]
+build_timeout_sec = 600.0
+cpus = 2
+memory_mb = 4096
+storage_mb = 20480
+gpus = 0
+allow_internet = true
+mcp_servers = []
+
+[verifier.env]
+
+[environment.env]
+KUBECONFIG = "/kube/kubeconfig.yaml"
+
+[solution.env]
+KUBECONFIG = "/kube/kubeconfig.yaml"

--- a/docs/templates/kubernetes-local-cluster-task/tests/test.sh
+++ b/docs/templates/kubernetes-local-cluster-task/tests/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p /logs/verifier
+
+if /tests/test_task.sh > /logs/verifier/test.log 2>&1; then
+  echo "1" > /logs/verifier/reward.txt
+else
+  echo "0" > /logs/verifier/reward.txt
+fi

--- a/docs/templates/kubernetes-local-cluster-task/tests/test_task.sh
+++ b/docs/templates/kubernetes-local-cluster-task/tests/test_task.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prepare-kubeconfig
+
+namespace="TODO_NAMESPACE"
+
+# TODO: verify semantic live-cluster state and reject shortcut fixes.
+kubectl -n "$namespace" get all

--- a/scripts/lint-kubernetes-rbac.py
+++ b/scripts/lint-kubernetes-rbac.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Lint Kubernetes task agent RBAC for shortcut-prone privileges."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import sys
+
+
+WRITE_VERBS = {"create", "delete", "deletecollection", "patch", "update", "*"}
+MUTATING_VERBS = {"delete", "deletecollection", "patch", "update", "*"}
+CREATE_GUARDED_RESOURCES = {
+    "pods",
+    "services",
+    "deployments",
+    "daemonsets",
+    "statefulsets",
+    "jobs",
+    "cronjobs",
+}
+
+ALLOW_BROAD_WRITES = {
+    ("fix-job-command-argument", "batch", "jobs"),
+    ("replace-deprecated-ingress-api", "networking.k8s.io", "ingresses"),
+    ("restore-missing-configmap", "", "configmaps"),
+}
+
+
+@dataclass(frozen=True)
+class Rule:
+    api_groups: tuple[str, ...]
+    resources: tuple[str, ...]
+    resource_names: tuple[str, ...]
+    verbs: tuple[str, ...]
+    line: int
+
+
+@dataclass(frozen=True)
+class RbacDoc:
+    path: Path
+    task: str
+    kind: str
+    name: str
+    namespace: str
+    rules: tuple[Rule, ...]
+
+
+def parse_scalar_list(value: str) -> tuple[str, ...]:
+    value = value.strip()
+    if not value:
+        return ()
+    if value.startswith("["):
+        parsed = ast.literal_eval(value)
+        return tuple(str(item) for item in parsed)
+    if value.startswith("- "):
+        return (value[2:].strip().strip('"'),)
+    return (value.strip('"'),)
+
+
+def field_value(lines: list[str], index: int) -> tuple[tuple[str, ...], int]:
+    line = lines[index]
+    _, raw_value = line.split(":", 1)
+    raw_value = raw_value.strip()
+    if raw_value:
+        return parse_scalar_list(raw_value), index
+
+    next_index = index + 1
+    values: list[str] = []
+    while next_index < len(lines):
+        next_line = lines[next_index]
+        stripped = next_line.strip()
+        if not stripped:
+            next_index += 1
+            continue
+        if re.match(r"^[a-zA-Z][a-zA-Z0-9]*:", stripped) or stripped.startswith(
+            "- apiGroups:"
+        ):
+            break
+        if stripped.startswith("[") and not stripped.endswith("]"):
+            parts = [stripped]
+            while next_index + 1 < len(lines) and not parts[-1].strip().endswith("]"):
+                next_index += 1
+                parts.append(lines[next_index].strip())
+            values.extend(parse_scalar_list(" ".join(parts)))
+            next_index += 1
+            continue
+        values.extend(parse_scalar_list(stripped))
+        next_index += 1
+    return tuple(values), next_index - 1
+
+
+def simple_metadata_value(lines: list[str], field: str) -> str:
+    in_metadata = False
+    for line in lines:
+        if line == "metadata:":
+            in_metadata = True
+            continue
+        if in_metadata:
+            if line and not line.startswith(" "):
+                return ""
+            stripped = line.strip()
+            if stripped.startswith(f"{field}:"):
+                return stripped.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+def simple_top_value(lines: list[str], field: str) -> str:
+    for line in lines:
+        if line.startswith(f"{field}:"):
+            return line.split(":", 1)[1].strip().strip('"')
+    return ""
+
+
+def parse_rules(lines: list[str]) -> tuple[Rule, ...]:
+    rules: list[Rule] = []
+    current: dict[str, tuple[str, ...] | int] | None = None
+
+    index = 0
+    while index < len(lines):
+        stripped = lines[index].strip()
+        if stripped.startswith("- apiGroups:"):
+            if current:
+                rules.append(make_rule(current))
+            current = {"line": index + 1}
+            current["apiGroups"], index = field_value(lines, index)
+        elif current and any(
+            stripped.startswith(f"{field}:")
+            for field in ("resources", "resourceNames", "verbs")
+        ):
+            field = stripped.split(":", 1)[0]
+            current[field], index = field_value(lines, index)
+        index += 1
+
+    if current:
+        rules.append(make_rule(current))
+
+    return tuple(rules)
+
+
+def make_rule(data: dict[str, tuple[str, ...] | int]) -> Rule:
+    def values(field: str) -> tuple[str, ...]:
+        value = data.get(field, ())
+        if isinstance(value, tuple):
+            return value
+        return ()
+
+    return Rule(
+        api_groups=values("apiGroups"),
+        resources=values("resources"),
+        resource_names=values("resourceNames"),
+        verbs=values("verbs"),
+        line=int(data.get("line", 1)),
+    )
+
+
+def parse_docs(path: Path) -> list[RbacDoc]:
+    docs: list[RbacDoc] = []
+    task = path.parts[2]
+
+    for raw_doc in re.split(r"(?m)^---\s*$", path.read_text()):
+        lines = [line.rstrip() for line in raw_doc.splitlines() if line.strip()]
+        kind = simple_top_value(lines, "kind")
+        if kind not in {"Role", "ClusterRole"}:
+            continue
+
+        name = simple_metadata_value(lines, "name")
+        namespace = simple_metadata_value(lines, "namespace")
+        if not name.startswith("infra-bench"):
+            continue
+
+        docs.append(
+            RbacDoc(
+                path=path,
+                task=task,
+                kind=kind,
+                name=name,
+                namespace=namespace,
+                rules=parse_rules(lines),
+            )
+        )
+
+    return docs
+
+
+def is_allowed_broad_write(task: str, group: str, resource: str) -> bool:
+    return (task, group, resource) in ALLOW_BROAD_WRITES
+
+
+def lint_doc(doc: RbacDoc) -> list[str]:
+    errors: list[str] = []
+
+    for rule in doc.rules:
+        write_verbs = WRITE_VERBS.intersection(rule.verbs)
+        if not write_verbs:
+            continue
+
+        for group in rule.api_groups:
+            for resource in rule.resources:
+                location = f"{doc.path}:{rule.line}"
+                allowed = is_allowed_broad_write(doc.task, group, resource)
+
+                if doc.kind == "ClusterRole":
+                    errors.append(
+                        f"{location}: {doc.name} grants cluster-scope write "
+                        f"verbs {sorted(write_verbs)} on {group or 'core'}/{resource}"
+                    )
+
+                if resource == "configmaps" and not allowed:
+                    errors.append(
+                        f"{location}: agent RBAC must not grant ConfigMap writes "
+                        f"without an explicit task exception"
+                    )
+
+                if (
+                    "create" in write_verbs
+                    and resource in CREATE_GUARDED_RESOURCES
+                    and not allowed
+                ):
+                    errors.append(
+                        f"{location}: agent RBAC grants create on shortcut-prone "
+                        f"resource {group or 'core'}/{resource}"
+                    )
+
+                if (
+                    MUTATING_VERBS.intersection(write_verbs)
+                    and not rule.resource_names
+                    and not allowed
+                ):
+                    errors.append(
+                        f"{location}: mutating agent RBAC on {group or 'core'}/{resource} "
+                        "must use resourceNames or an explicit exception"
+                    )
+
+    return errors
+
+
+def main() -> int:
+    root = Path("datasets/kubernetes-core")
+    errors: list[str] = []
+
+    for path in sorted(root.glob("*/environment/workspace/bootstrap/*.yaml")):
+        for doc in parse_docs(path):
+            errors.extend(lint_doc(doc))
+
+    if errors:
+        print("Kubernetes RBAC lint failed:", file=sys.stderr)
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print("kubernetes rbac lint ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-structure.sh
+++ b/scripts/validate-structure.sh
@@ -9,6 +9,25 @@ fail() {
   exit 1
 }
 
+service_block() {
+  local compose_file="$1"
+  local service="$2"
+
+  awk -v service="$service" '
+    $0 ~ "^  " service ":$" {
+      in_service = 1
+      print
+      next
+    }
+    in_service && $0 ~ /^  [[:alnum:]_-]+:$/ {
+      exit
+    }
+    in_service {
+      print
+    }
+  ' "$compose_file"
+}
+
 [[ -f LICENSE ]] || fail "missing LICENSE"
 [[ -f AGENTS.md ]] || fail "missing AGENTS.md"
 [[ -d docs ]] || fail "missing docs/"
@@ -26,8 +45,30 @@ while IFS= read -r task_toml; do
     if grep -q 'bootstrap-cluster' "$task_dir/environment/Dockerfile"; then
       fail "$task_dir agent Dockerfile must not copy bootstrap-cluster"
     fi
+    if grep -Eq 'COPY[[:space:]]+scripts/[[:space:]]' "$task_dir/environment/Dockerfile"; then
+      fail "$task_dir agent Dockerfile must copy only scripts/prepare-kubeconfig"
+    fi
+    if grep -Eq 'COPY[[:space:]]+.*workspace/bootstrap|ADD[[:space:]]+.*workspace/bootstrap' "$task_dir/environment/Dockerfile"; then
+      fail "$task_dir agent Dockerfile must not copy workspace/bootstrap"
+    fi
+    grep -q 'bootstrap-cluster' "$task_dir/environment/Dockerfile.bootstrap" \
+      || fail "$task_dir bootstrap Dockerfile must include bootstrap-cluster"
     grep -q 'Dockerfile.bootstrap' "$task_dir/environment/docker-compose.yaml" \
       || fail "$task_dir bootstrap service must build from Dockerfile.bootstrap"
+
+    main_block="$(service_block "$task_dir/environment/docker-compose.yaml" main)"
+    bootstrap_block="$(service_block "$task_dir/environment/docker-compose.yaml" bootstrap)"
+
+    grep -q 'agent-kubeconfig:/kube:ro' <<<"$main_block" \
+      || fail "$task_dir main service must mount agent kubeconfig read-only"
+    if grep -q 'admin-kubeconfig:/admin-kube' <<<"$main_block"; then
+      fail "$task_dir main service must not mount admin kubeconfig"
+    fi
+    if grep -q './workspace/bootstrap' <<<"$main_block"; then
+      fail "$task_dir main service must not mount workspace/bootstrap"
+    fi
+    grep -q './workspace/bootstrap:/bootstrap:ro' <<<"$bootstrap_block" \
+      || fail "$task_dir bootstrap service must mount workspace/bootstrap read-only"
   fi
   [[ -f "$task_dir/solution/solve.sh" ]] || fail "$task_dir missing solution/solve.sh"
   [[ -x "$task_dir/solution/solve.sh" ]] || fail "$task_dir solution/solve.sh is not executable"


### PR DESCRIPTION
Add the hardening work needed before starting medium Kubernetes tasks.

This adds a Kubernetes RBAC lint that catches shortcut-prone agent permissions, extends structure validation for the two-image local-cluster boundary, and wires both checks into PR validation. It also keeps a Kubernetes Core oracle sweep workflow available only as an explicit manual opt-in; there is no scheduled oracle run so the low-latency runners stay focused on fast validation by default.

The existing easy tasks keep passing after narrowing three agent Roles with resourceNames. The Kubernetes docs and infra-task skills now record the medium-task progression and point future implementations at a reusable two-image local-cluster template.

Validated locally with ./scripts/lint-files.sh, shell syntax checks, ./scripts/validate-structure.sh, python3 scripts/lint-kubernetes-rbac.py, Harbor sync for both datasets followed by Taplo formatting, and a full Kubernetes Core oracle run: 22/22 tasks passed, mean reward 1.000, 0 exceptions.