### PR TITLE
fix(kubernetes): Neutralize easy task namespaces

### DIFF
--- a/datasets/kubernetes-core/add-maintenance-toleration/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/add-maintenance-toleration/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="maintenance-debug"
+namespace="warehouse-team"
 deployment="maintenance-worker"
 agent_secret="infra-bench-agent-token"
 

--- a/datasets/kubernetes-core/add-maintenance-toleration/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/add-maintenance-toleration/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n maintenance-debug get deployment maintenance-worker >/dev/null 2>&1; then
+    || kubectl -n warehouse-team get deployment maintenance-worker >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/add-maintenance-toleration/environment/workspace/bootstrap/maintenance.yaml
+++ b/datasets/kubernetes-core/add-maintenance-toleration/environment/workspace/bootstrap/maintenance.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: maintenance-debug
+  name: warehouse-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: maintenance-debug
+  namespace: warehouse-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: maintenance-debug
+  namespace: warehouse-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: maintenance-debug
+  namespace: warehouse-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "services"]
@@ -42,11 +42,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: maintenance-debug
+  namespace: warehouse-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: maintenance-debug
+    namespace: warehouse-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,7 +55,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-node-reader-maintenance-debug
+  name: infra-bench-node-reader-warehouse-team
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -64,21 +64,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-node-reader-maintenance-debug
+  name: infra-bench-node-reader-warehouse-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: maintenance-debug
+    namespace: warehouse-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-node-reader-maintenance-debug
+  name: infra-bench-node-reader-warehouse-team
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: maintenance-worker
-  namespace: maintenance-debug
+  namespace: warehouse-team
   labels:
     app: maintenance-worker
 spec:
@@ -104,7 +104,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: maintenance-debug
+  namespace: warehouse-team
 data:
   deployment_uid: ""
   node_name: ""

--- a/datasets/kubernetes-core/add-maintenance-toleration/instruction.md
+++ b/datasets/kubernetes-core/add-maintenance-toleration/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `maintenance-worker` Deployment in the `maintenance-debug` namespace is
+The `maintenance-worker` Deployment in the `warehouse-team` namespace is
 intended to run on the maintenance node, but its pod is Pending because it does
 not tolerate the node taint.
 

--- a/datasets/kubernetes-core/add-maintenance-toleration/solution/solve.sh
+++ b/datasets/kubernetes-core/add-maintenance-toleration/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="maintenance-debug"
+namespace="warehouse-team"
 deployment="maintenance-worker"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/add-maintenance-toleration/tests/test_toleration.sh
+++ b/datasets/kubernetes-core/add-maintenance-toleration/tests/test_toleration.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="maintenance-debug"
+namespace="warehouse-team"
 deployment="maintenance-worker"
 
 dump_debug() {

--- a/datasets/kubernetes-core/add-rbac-list-verb/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/add-rbac-list-verb/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="rbac-debug"
+namespace="audit-team"
 job="config-audit"
 target_role="diagnostic-config-reader"
 target_rolebinding="diagnostic-config-reader"

--- a/datasets/kubernetes-core/add-rbac-list-verb/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/add-rbac-list-verb/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n rbac-debug get job config-audit >/dev/null 2>&1; then
+    || kubectl -n audit-team get job config-audit >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/add-rbac-list-verb/environment/workspace/bootstrap/rbac.yaml
+++ b/datasets/kubernetes-core/add-rbac-list-verb/environment/workspace/bootstrap/rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: rbac-debug
+  name: audit-team
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: diagnostic-settings
-  namespace: rbac-debug
+  namespace: audit-team
 data:
   target: |
     configmaps
@@ -18,13 +18,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: diagnostic-runner
-  namespace: rbac-debug
+  namespace: audit-team
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: diagnostic-config-reader
-  namespace: rbac-debug
+  namespace: audit-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -34,11 +34,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: diagnostic-config-reader
-  namespace: rbac-debug
+  namespace: audit-team
 subjects:
   - kind: ServiceAccount
     name: diagnostic-runner
-    namespace: rbac-debug
+    namespace: audit-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -48,7 +48,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: config-audit
-  namespace: rbac-debug
+  namespace: audit-team
   labels:
     app: config-audit
 spec:
@@ -68,7 +68,7 @@ spec:
             - -ec
             - |
               token="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-              api="https://kubernetes.default.svc/api/v1/namespaces/rbac-debug/configmaps"
+              api="https://kubernetes.default.svc/api/v1/namespaces/audit-team/configmaps"
 
               while true; do
                 if wget --header "Authorization: Bearer ${token}" --no-check-certificate -q -O /tmp/configmaps.json "${api}" 2>/tmp/error.log; then
@@ -87,13 +87,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: rbac-debug
+  namespace: audit-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: rbac-debug
+  namespace: audit-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -102,7 +102,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: rbac-debug
+  namespace: audit-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "serviceaccounts"]
@@ -125,11 +125,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: rbac-debug
+  namespace: audit-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: rbac-debug
+    namespace: audit-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -139,7 +139,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: rbac-debug
+  namespace: audit-team
 data:
   role_uid: ""
   rolebinding_uid: ""

--- a/datasets/kubernetes-core/add-rbac-list-verb/instruction.md
+++ b/datasets/kubernetes-core/add-rbac-list-verb/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `config-audit` Job in the `rbac-debug` namespace is unable to complete
+The `config-audit` Job in the `audit-team` namespace is unable to complete
 because its ServiceAccount does not have the exact RBAC permission it needs to
 inspect ConfigMaps.
 

--- a/datasets/kubernetes-core/add-rbac-list-verb/solution/solve.sh
+++ b/datasets/kubernetes-core/add-rbac-list-verb/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="rbac-debug"
+namespace="audit-team"
 role="diagnostic-config-reader"
 job="config-audit"
 

--- a/datasets/kubernetes-core/add-rbac-list-verb/tests/test_rbac_list_verb.sh
+++ b/datasets/kubernetes-core/add-rbac-list-verb/tests/test_rbac_list_verb.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="rbac-debug"
+namespace="audit-team"
 job="config-audit"
 target_role="diagnostic-config-reader"
 target_rolebinding="diagnostic-config-reader"
@@ -161,7 +161,7 @@ rolebinding_ref="$(
     -o jsonpath='{.subjects[*].kind}{"|"}{.subjects[*].name}{"|"}{.subjects[*].namespace}{"|"}{.roleRef.apiGroup}{"|"}{.roleRef.kind}{"|"}{.roleRef.name}'
 )"
 
-if [[ "$rolebinding_ref" != "ServiceAccount|diagnostic-runner|rbac-debug|rbac.authorization.k8s.io|Role|diagnostic-config-reader" ]]; then
+if [[ "$rolebinding_ref" != "ServiceAccount|diagnostic-runner|audit-team|rbac.authorization.k8s.io|Role|diagnostic-config-reader" ]]; then
   echo "RoleBinding $target_rolebinding no longer binds $target_role to $target_serviceaccount: $rolebinding_ref" >&2
   exit 1
 fi

--- a/datasets/kubernetes-core/allow-api-network-policy/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/allow-api-network-policy/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="policy-debug"
+namespace="retail-gateway"
 policy="allow-frontend-to-api"
 agent_secret="infra-bench-agent-token"
 

--- a/datasets/kubernetes-core/allow-api-network-policy/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/allow-api-network-policy/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n policy-debug get networkpolicy allow-frontend-to-api >/dev/null 2>&1; then
+    || kubectl -n retail-gateway get networkpolicy allow-frontend-to-api >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/allow-api-network-policy/environment/workspace/bootstrap/network.yaml
+++ b/datasets/kubernetes-core/allow-api-network-policy/environment/workspace/bootstrap/network.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: policy-debug
+  name: retail-gateway
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: policy-debug
+  namespace: retail-gateway
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: policy-debug
+  namespace: retail-gateway
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: policy-debug
+  namespace: retail-gateway
 rules:
   - apiGroups: [""]
     resources:
@@ -57,11 +57,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: policy-debug
+  namespace: retail-gateway
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: policy-debug
+    namespace: retail-gateway
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -71,7 +71,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api
-  namespace: policy-debug
+  namespace: retail-gateway
   labels:
     app: api
     tier: backend
@@ -97,7 +97,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api
-  namespace: policy-debug
+  namespace: retail-gateway
   labels:
     app: api
 spec:
@@ -112,7 +112,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  namespace: policy-debug
+  namespace: retail-gateway
   labels:
     app: frontend
     tier: frontend
@@ -136,7 +136,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: intruder
-  namespace: policy-debug
+  namespace: retail-gateway
   labels:
     app: intruder
     tier: other
@@ -160,7 +160,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-frontend-to-api
-  namespace: policy-debug
+  namespace: retail-gateway
 spec:
   podSelector:
     matchLabels:
@@ -180,7 +180,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: policy-debug
+  namespace: retail-gateway
 data:
   policy_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/allow-api-network-policy/instruction.md
+++ b/datasets/kubernetes-core/allow-api-network-policy/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `frontend` workload in the `policy-debug` namespace cannot reach the
+The `frontend` workload in the `retail-gateway` namespace cannot reach the
 `api` Service even though both workloads are healthy. An existing NetworkPolicy
 is meant to keep the API isolated while allowing only the frontend traffic path.
 

--- a/datasets/kubernetes-core/allow-api-network-policy/solution/solve.sh
+++ b/datasets/kubernetes-core/allow-api-network-policy/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="policy-debug"
+namespace="retail-gateway"
 policy="allow-frontend-to-api"
 
 kubectl -n "$namespace" patch networkpolicy "$policy" \

--- a/datasets/kubernetes-core/allow-api-network-policy/tests/test_network_policy.sh
+++ b/datasets/kubernetes-core/allow-api-network-policy/tests/test_network_policy.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="policy-debug"
+namespace="retail-gateway"
 policy="allow-frontend-to-api"
 
 dump_debug() {

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -13,91 +13,91 @@ email = "thomas@kubeply.com"
 
 [[tasks]]
 name = "kubeply/debug-service-endpoints"
-digest = "sha256:ad2522db0bc6e92192e36cd9d5e64e94040a25a79f45561e68e72e57aa7f91df"
+digest = "sha256:32f7f6c46e6c460fa1a012ab19ed73ebc3bc63f3cb8eb1f51888ff42d094db7d"
 
 [[tasks]]
 name = "kubeply/repair-readiness-probe-path"
-digest = "sha256:391b7bf3bf75fb5e524e2524286e032c8ccf2cf53b62ec08c1008a7decccc0dc"
+digest = "sha256:81dc634025c51ef948f420a222ba87124eb0838f95e82930287a6147f58e98f8"
 
 [[tasks]]
 name = "kubeply/fix-config-key-reference"
-digest = "sha256:e51141f46ae57aed0f23eb05e401814bf4c7518851443cd6aab69badf0a83716"
+digest = "sha256:17f5c2b8efd9099036dca3f2af0e64ae928d728481d6cb8e1df8d71148295eb8"
 
 [[tasks]]
 name = "kubeply/add-rbac-list-verb"
-digest = "sha256:11a6274a0f74837f28d7db6b0ef7f23bb5c569ea1df3499497ca65fdd612dbbc"
+digest = "sha256:ada54ce64fb45a8936e9878622c1d383879ddaf84147cb3906941698ece7f2f6"
 
 [[tasks]]
 name = "kubeply/fix-node-selector-mismatch"
-digest = "sha256:66acc2d2a504ccaa78c5390fb1ef635c0bc647457ff14959757fcc0c437d39cf"
+digest = "sha256:9f5102aa9da536bec2f00e3248ffaf2ee426724edb2e0217bb3ed0c9d8595063"
 
 [[tasks]]
 name = "kubeply/rightsize-cpu-request"
-digest = "sha256:2f9a76704667c75df2c60ec316464a59422eb70b19f4bc6413b6be819c8820f2"
+digest = "sha256:915a17b8ab98802fc3623f5ba50d95c8ccc6b3498f995c059cb161685522439d"
 
 [[tasks]]
 name = "kubeply/target-gpu-node-label"
-digest = "sha256:8e86b52bc36decf6505e783640c21eb53c620c489157667a0f391be77807b82a"
+digest = "sha256:ecce3384c16f848c6e6d7524dc3ba72b36a37a28fa134b8e786603a300c41908"
 
 [[tasks]]
 name = "kubeply/fix-pvc-mount-claim"
-digest = "sha256:eb0953b533f0358e6b6ee0b813f08dd13d16057fa4809fe69199dfebb60ae50f"
+digest = "sha256:4f85370ccb1872c50c6080e262ee05a2766c5ef695a36fbeda1b2471ede0ee23"
 
 [[tasks]]
 name = "kubeply/allow-api-network-policy"
-digest = "sha256:7d39d5d8a682743ef5e5546b29966fdab352f1c53d496c3119bdce97aab05b50"
+digest = "sha256:162cf4019676ad0fc6b8bf6eebe4db9e7fbbb69f354cd927b57e33c90a8a8e03"
 
 [[tasks]]
 name = "kubeply/reconnect-frontend-api"
-digest = "sha256:15194a10caf9a120f598b33218331aab85753356f979667cf3ed1a22652806fa"
+digest = "sha256:603f70744af5c5fb65da806d0683f1a7638f95fd042ae1c644eba531f1dc2690"
 
 [[tasks]]
 name = "kubeply/fix-restricted-security-context"
-digest = "sha256:9056620af630b79c28b367f991de19152631ff7ae862f68b42973d8b0ca6e33b"
+digest = "sha256:e3ad7489242e4ec2ccc4a65452a6e2849e049ae51e45ac2e7cdc2643447c0e00"
 
 [[tasks]]
 name = "kubeply/fix-crashloop-env-var"
-digest = "sha256:13bc3e0bb80c9ecfb5b8ad0d3006e759d616863e88f548e0748c8de3ab825314"
+digest = "sha256:e3d4d1b38f26ebb7aa4d370ea2d9834694243251671980bd38ab8e58e2029530"
 
 [[tasks]]
 name = "kubeply/fix-service-dns-name"
-digest = "sha256:2ee03fef01302bee66907a75a65069de512ed15cb1021f214f563de26fdcdf23"
+digest = "sha256:68c7e588d799561c87ef7e2802e8b0db87ca4389c2e68ad7f54cf698e76eaa51"
 
 [[tasks]]
 name = "kubeply/fix-job-command-argument"
-digest = "sha256:2ee0a8a720a05d5be84bed0e18d6515fcb7cbccd3093bc63401593f985f08d81"
+digest = "sha256:ab2854d99b05e7c4eff56d9ff13394230da47773b2390830486bfb3dc76c6df8"
 
 [[tasks]]
 name = "kubeply/fix-quirky-health-endpoint"
-digest = "sha256:8836a9785636ce9186481a46a149572dc2fad203812b2bd9788ae20282d7012f"
+digest = "sha256:6030032247f8048d1de89e6989fd70705d255118b017783a310629fa1403cb50"
 
 [[tasks]]
 name = "kubeply/repair-ingress-backend-port"
-digest = "sha256:c9f0632cc679a3e360a02d131e681080d96a927cc61a36281d3384959a14b666"
+digest = "sha256:91c45ead512ee7493dab27a590673d5a6f444bda8ed5da710b3eec4d9f044ac4"
 
 [[tasks]]
 name = "kubeply/fix-hpa-scale-target"
-digest = "sha256:812d077c3522c49c6a62668e19b39d2e215388af2457570721777b156fcc944c"
+digest = "sha256:eb5cf6d8042c96158e83662b67f8fffd8c23a5c3c7b3a49aaa7b766fb60059cf"
 
 [[tasks]]
 name = "kubeply/fix-controller-service-selector"
-digest = "sha256:4a407e8a45ebdf090eb4bfb7398d8fad5fea1c1d6e11842bed5e1074093bc9b4"
+digest = "sha256:870f5a9787a5d188a586991cf0a50e46198574b5f00f891379f3eb53a5c06d4b"
 
 [[tasks]]
 name = "kubeply/restore-missing-configmap"
-digest = "sha256:3604a02aa147f634c606962fb0cc63ebb311b4503c76bf37dcf19b1df1690616"
+digest = "sha256:e5fd8e4ad6bc8cb6a98b73f01e067902ef26a4c1bca81588a314ef5e4a940463"
 
 [[tasks]]
 name = "kubeply/replace-deprecated-ingress-api"
-digest = "sha256:772e872ac341a63db23ea3d90dbe6ddc0e39e3f2bc2c126a412e75f0846858fb"
+digest = "sha256:958701ea0808590caf07a5f54658925bf9608bfd5e123045f49b0a41052be1ad"
 
 [[tasks]]
 name = "kubeply/add-maintenance-toleration"
-digest = "sha256:b99f0e62f6004c4018d72e2dd94a93a26199ef89d2464694b7c4b5e0661034da"
+digest = "sha256:1cb5a36f7083451b81d9a75ce07478bbe8021d75e8a8e0aaf8bee0c2a274e744"
 
 [[tasks]]
 name = "kubeply/fix-simple-cr-field"
-digest = "sha256:ecc37de7bde7fe9be3e5c7fc79beafd08c9b0ead3d72e7ce84bea4e9f24c9292"
+digest = "sha256:c68947e1b4cedd1c6ef6f8f7e7f387b9b3e41445dd1f03e86b9fcb78f88e069a"
 
 
 [[files]]

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="web-debug"
+namespace="web-platform"
 agent_secret="infra-bench-agent-token"
 
 prepare-kubeconfig

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n web-debug get deployment web >/dev/null 2>&1; then
+    || kubectl -n web-platform get deployment web >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
+++ b/datasets/kubernetes-core/debug-service-endpoints/environment/workspace/bootstrap/web.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: web-debug
+  name: web-platform
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: web-debug
+  namespace: web-platform
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: web-debug
+  namespace: web-platform
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: web-debug
+  namespace: web-platform
 rules:
   - apiGroups: [""]
     resources:
@@ -43,11 +43,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: web-debug
+  namespace: web-platform
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: web-debug
+    namespace: web-platform
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: web
-  namespace: web-debug
+  namespace: web-platform
   labels:
     app: web
 spec:
@@ -81,7 +81,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: web
-  namespace: web-debug
+  namespace: web-platform
 spec:
   selector:
     app: api
@@ -94,7 +94,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: web-debug
+  namespace: web-platform
 data:
   deployment_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/debug-service-endpoints/instruction.md
+++ b/datasets/kubernetes-core/debug-service-endpoints/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `web-debug` namespace contains a Deployment named `web` and a Service named
+The `web-platform` namespace contains a Deployment named `web` and a Service named
 `web`. The pods are running, but the Service has no usable endpoints, so traffic
 sent to the Service cannot reach the workload.
 

--- a/datasets/kubernetes-core/debug-service-endpoints/solution/solve.sh
+++ b/datasets/kubernetes-core/debug-service-endpoints/solution/solve.sh
@@ -3,14 +3,14 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-kubectl -n web-debug patch service web \
+kubectl -n web-platform patch service web \
   --type merge \
   --patch '{"spec":{"selector":{"app":"web"}}}'
 
-kubectl -n web-debug rollout status deployment/web --timeout=120s
+kubectl -n web-platform rollout status deployment/web --timeout=120s
 
 for _ in $(seq 1 60); do
-  endpoints="$(kubectl -n web-debug get endpoints web -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
+  endpoints="$(kubectl -n web-platform get endpoints web -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
   if [[ -n "$endpoints" ]]; then
     exit 0
   fi

--- a/datasets/kubernetes-core/debug-service-endpoints/tests/test_service_endpoints.sh
+++ b/datasets/kubernetes-core/debug-service-endpoints/tests/test_service_endpoints.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="web-debug"
+namespace="web-platform"
 
 dump_debug() {
   echo "--- namespace ---"

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="config-debug"
+namespace="orders-team"
 deployment="orders-api"
 configmap="orders-config"
 agent_secret="infra-bench-agent-token"

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n config-debug get deployment orders-api >/dev/null 2>&1; then
+    || kubectl -n orders-team get deployment orders-api >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-config-key-reference/environment/workspace/bootstrap/config.yaml
+++ b/datasets/kubernetes-core/fix-config-key-reference/environment/workspace/bootstrap/config.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: config-debug
+  name: orders-team
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: orders-config
-  namespace: config-debug
+  namespace: orders-team
 data:
   mode: |
     live
@@ -18,13 +18,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: config-debug
+  namespace: orders-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: config-debug
+  namespace: orders-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: config-debug
+  namespace: orders-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log"]
@@ -53,11 +53,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: config-debug
+  namespace: orders-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: config-debug
+    namespace: orders-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -67,7 +67,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-api
-  namespace: config-debug
+  namespace: orders-team
   labels:
     app: orders-api
 spec:
@@ -97,7 +97,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: config-debug
+  namespace: orders-team
 data:
   deployment_uid: ""
   configmap_uid: ""

--- a/datasets/kubernetes-core/fix-config-key-reference/instruction.md
+++ b/datasets/kubernetes-core/fix-config-key-reference/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `config-debug` namespace contains a Deployment named `orders-api` and a
+The `orders-team` namespace contains a Deployment named `orders-api` and a
 ConfigMap named `orders-config`. The Deployment's pods cannot start because one
 environment variable references a ConfigMap key that is not present.
 

--- a/datasets/kubernetes-core/fix-config-key-reference/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-config-key-reference/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="config-debug"
+namespace="orders-team"
 deployment="orders-api"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/fix-config-key-reference/tests/test_config_key_reference.sh
+++ b/datasets/kubernetes-core/fix-config-key-reference/tests/test_config_key_reference.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="config-debug"
+namespace="orders-team"
 deployment="orders-api"
 configmap="orders-config"
 

--- a/datasets/kubernetes-core/fix-controller-service-selector/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-controller-service-selector/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="controller-debug"
+namespace="metrics-team"
 deployment="metrics-adapter"
 service="metrics-adapter"
 agent_secret="infra-bench-agent-token"

--- a/datasets/kubernetes-core/fix-controller-service-selector/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-controller-service-selector/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n controller-debug get deployment metrics-adapter >/dev/null 2>&1; then
+    || kubectl -n metrics-team get deployment metrics-adapter >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-controller-service-selector/environment/workspace/bootstrap/controller.yaml
+++ b/datasets/kubernetes-core/fix-controller-service-selector/environment/workspace/bootstrap/controller.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: controller-debug
+  name: metrics-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: controller-debug
+  namespace: metrics-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: controller-debug
+  namespace: metrics-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: controller-debug
+  namespace: metrics-team
 rules:
   - apiGroups: [""]
     resources:
@@ -43,11 +43,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: controller-debug
+  namespace: metrics-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: controller-debug
+    namespace: metrics-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metrics-adapter
-  namespace: controller-debug
+  namespace: metrics-team
   labels:
     app.kubernetes.io/name: metrics-adapter
     app.kubernetes.io/component: controller
@@ -84,7 +84,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: metrics-adapter
-  namespace: controller-debug
+  namespace: metrics-team
   labels:
     app.kubernetes.io/name: metrics-adapter
     app.kubernetes.io/component: controller
@@ -101,7 +101,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: controller-debug
+  namespace: metrics-team
 data:
   deployment_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/fix-controller-service-selector/instruction.md
+++ b/datasets/kubernetes-core/fix-controller-service-selector/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `metrics-adapter` controller Deployment in the `controller-debug` namespace
+The `metrics-adapter` controller Deployment in the `metrics-team` namespace
 is running, but its `metrics-adapter` Service has no endpoints after a
 values-style label mismatch.
 

--- a/datasets/kubernetes-core/fix-controller-service-selector/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-controller-service-selector/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="controller-debug"
+namespace="metrics-team"
 service="metrics-adapter"
 
 kubectl -n "$namespace" patch service "$service" \

--- a/datasets/kubernetes-core/fix-controller-service-selector/tests/test_controller_service.sh
+++ b/datasets/kubernetes-core/fix-controller-service-selector/tests/test_controller_service.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="controller-debug"
+namespace="metrics-team"
 deployment="metrics-adapter"
 service="metrics-adapter"
 

--- a/datasets/kubernetes-core/fix-crashloop-env-var/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="incident-debug"
+namespace="payments-team"
 deployment="api-worker"
 service="api-worker"
 settings_configmap="api-worker-settings"

--- a/datasets/kubernetes-core/fix-crashloop-env-var/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n incident-debug get deployment api-worker >/dev/null 2>&1; then
+    || kubectl -n payments-team get deployment api-worker >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-crashloop-env-var/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/environment/workspace/bootstrap/app.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: incident-debug
+  name: payments-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: incident-debug
+  namespace: payments-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: incident-debug
+  namespace: payments-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: incident-debug
+  namespace: payments-team
 rules:
   - apiGroups: [""]
     resources:
@@ -43,11 +43,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: incident-debug
+  namespace: payments-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: incident-debug
+    namespace: payments-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,7 +57,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: api-worker-settings
-  namespace: incident-debug
+  namespace: payments-team
 data:
   expected_mode: production
   owner: platform
@@ -66,7 +66,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-worker
-  namespace: incident-debug
+  namespace: payments-team
   labels:
     app: api-worker
 spec:
@@ -112,7 +112,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-worker
-  namespace: incident-debug
+  namespace: payments-team
 spec:
   selector:
     app: api-worker
@@ -125,7 +125,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: incident-debug
+  namespace: payments-team
 data:
   deployment_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/fix-crashloop-env-var/instruction.md
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-One application pod in the `incident-debug` namespace is crash-looping because
+One application pod in the `payments-team` namespace is crash-looping because
 a Deployment environment variable has an invalid value. Use events, pod status,
 and logs to identify the failing workload and the value it expects.
 

--- a/datasets/kubernetes-core/fix-crashloop-env-var/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="incident-debug"
+namespace="payments-team"
 deployment="api-worker"
 
 kubectl -n "$namespace" set env deployment/"$deployment" APP_MODE=production

--- a/datasets/kubernetes-core/fix-crashloop-env-var/tests/test_crashloop_env_var.sh
+++ b/datasets/kubernetes-core/fix-crashloop-env-var/tests/test_crashloop_env_var.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="incident-debug"
+namespace="payments-team"
 deployment="api-worker"
 service="api-worker"
 settings_configmap="api-worker-settings"

--- a/datasets/kubernetes-core/fix-hpa-scale-target/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="autoscale-debug"
+namespace="catalog-team"
 deployment="catalog-api"
 hpa="catalog-api"
 agent_secret="infra-bench-agent-token"

--- a/datasets/kubernetes-core/fix-hpa-scale-target/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n autoscale-debug get hpa catalog-api >/dev/null 2>&1; then
+    || kubectl -n catalog-team get hpa catalog-api >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-hpa-scale-target/environment/workspace/bootstrap/hpa.yaml
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/environment/workspace/bootstrap/hpa.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: autoscale-debug
+  name: catalog-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: autoscale-debug
+  namespace: catalog-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: autoscale-debug
+  namespace: catalog-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: autoscale-debug
+  namespace: catalog-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "services"]
@@ -45,11 +45,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: autoscale-debug
+  namespace: catalog-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: autoscale-debug
+    namespace: catalog-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -59,7 +59,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalog-api
-  namespace: autoscale-debug
+  namespace: catalog-team
   labels:
     app: catalog-api
 spec:
@@ -90,7 +90,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: catalog-api
-  namespace: autoscale-debug
+  namespace: catalog-team
   labels:
     app: catalog-api
 spec:
@@ -112,7 +112,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: autoscale-debug
+  namespace: catalog-team
 data:
   deployment_uid: ""
   hpa_uid: ""

--- a/datasets/kubernetes-core/fix-hpa-scale-target/instruction.md
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `catalog-api` workload in the `autoscale-debug` namespace is healthy, but
+The `catalog-api` workload in the `catalog-team` namespace is healthy, but
 its HorizontalPodAutoscaler cannot resolve the workload it is supposed to
 observe because the scale target reference points to the wrong Deployment name.
 

--- a/datasets/kubernetes-core/fix-hpa-scale-target/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="autoscale-debug"
+namespace="catalog-team"
 hpa="catalog-api"
 
 kubectl -n "$namespace" patch hpa "$hpa" \

--- a/datasets/kubernetes-core/fix-hpa-scale-target/tests/test_hpa_target.sh
+++ b/datasets/kubernetes-core/fix-hpa-scale-target/tests/test_hpa_target.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="autoscale-debug"
+namespace="catalog-team"
 deployment="catalog-api"
 hpa="catalog-api"
 

--- a/datasets/kubernetes-core/fix-job-command-argument/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-job-command-argument/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="batch-debug"
+namespace="catalog-ops"
 job="catalog-maintenance"
 runner_serviceaccount="maintenance-runner"
 script_configmap="maintenance-script"

--- a/datasets/kubernetes-core/fix-job-command-argument/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-job-command-argument/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n batch-debug get job catalog-maintenance >/dev/null 2>&1; then
+    || kubectl -n catalog-ops get job catalog-maintenance >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-job-command-argument/environment/workspace/bootstrap/maintenance.yaml
+++ b/datasets/kubernetes-core/fix-job-command-argument/environment/workspace/bootstrap/maintenance.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: batch-debug
+  name: catalog-ops
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: batch-debug
+  namespace: catalog-ops
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: batch-debug
+  namespace: catalog-ops
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,13 +22,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: maintenance-runner
-  namespace: batch-debug
+  namespace: catalog-ops
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: batch-debug
+  namespace: catalog-ops
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "serviceaccounts"]
@@ -50,11 +50,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: batch-debug
+  namespace: catalog-ops
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: batch-debug
+    namespace: catalog-ops
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -64,7 +64,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: maintenance-script
-  namespace: batch-debug
+  namespace: catalog-ops
 data:
   maintenance.sh: |
     set -eu
@@ -81,7 +81,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: catalog-maintenance
-  namespace: batch-debug
+  namespace: catalog-ops
   labels:
     app: catalog-maintenance
     job-type: maintenance

--- a/datasets/kubernetes-core/fix-job-command-argument/instruction.md
+++ b/datasets/kubernetes-core/fix-job-command-argument/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `catalog-maintenance` Job in the `batch-debug` namespace is failing because
+The `catalog-maintenance` Job in the `catalog-ops` namespace is failing because
 its command uses one wrong argument for the mounted maintenance script.
 
 Repair the live cluster so the `catalog-maintenance` Job completes
@@ -16,7 +16,7 @@ Constraints:
 
 - Use `kubectl` to inspect the Job, failed pod, events, ConfigMap, and logs
   before changing anything.
-- Keep the Job named `catalog-maintenance` in the `batch-debug` namespace.
+- Keep the Job named `catalog-maintenance` in the `catalog-ops` namespace.
 - Keep the container image, mounted script ConfigMap, ServiceAccount, labels,
   and script volume unchanged.
 - The Job pod template is immutable, so recreating the same named Job is

--- a/datasets/kubernetes-core/fix-job-command-argument/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-job-command-argument/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="batch-debug"
+namespace="catalog-ops"
 job="catalog-maintenance"
 
 kubectl -n "$namespace" delete job "$job" --wait=true
@@ -13,7 +13,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: catalog-maintenance
-  namespace: batch-debug
+  namespace: catalog-ops
   labels:
     app: catalog-maintenance
     job-type: maintenance

--- a/datasets/kubernetes-core/fix-job-command-argument/tests/test_job_command_argument.sh
+++ b/datasets/kubernetes-core/fix-job-command-argument/tests/test_job_command_argument.sh
@@ -4,7 +4,7 @@ trap 'echo "Verifier failed near line ${LINENO}" >&2' ERR
 
 prepare-kubeconfig
 
-namespace="batch-debug"
+namespace="catalog-ops"
 job="catalog-maintenance"
 runner_serviceaccount="maintenance-runner"
 script_configmap="maintenance-script"

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="scheduling-debug"
+namespace="inventory-team"
 deployment="inventory-worker"
 agent_secret="infra-bench-agent-token"
 

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n scheduling-debug get deployment inventory-worker >/dev/null 2>&1; then
+    || kubectl -n inventory-team get deployment inventory-worker >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/environment/workspace/bootstrap/scheduling.yaml
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/environment/workspace/bootstrap/scheduling.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: scheduling-debug
+  name: inventory-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: scheduling-debug
+  namespace: inventory-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: scheduling-debug
+  namespace: inventory-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: scheduling-debug
+  namespace: inventory-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log"]
@@ -42,11 +42,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: scheduling-debug
+  namespace: inventory-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: scheduling-debug
+    namespace: inventory-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,7 +55,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-node-reader-scheduling-debug
+  name: infra-bench-node-reader-inventory-team
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -64,21 +64,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-node-reader-scheduling-debug
+  name: infra-bench-node-reader-inventory-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: scheduling-debug
+    namespace: inventory-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-node-reader-scheduling-debug
+  name: infra-bench-node-reader-inventory-team
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: inventory-worker
-  namespace: scheduling-debug
+  namespace: inventory-team
   labels:
     app: inventory-worker
 spec:
@@ -104,7 +104,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: scheduling-debug
+  namespace: inventory-team
 data:
   deployment_uid: ""
   node_name: ""

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/instruction.md
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `inventory-worker` Deployment in the `scheduling-debug` namespace cannot
+The `inventory-worker` Deployment in the `inventory-team` namespace cannot
 schedule its pods because its pod template selects a node label value that no
 node has.
 

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="scheduling-debug"
+namespace="inventory-team"
 deployment="inventory-worker"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/fix-node-selector-mismatch/tests/test_node_selector.sh
+++ b/datasets/kubernetes-core/fix-node-selector-mismatch/tests/test_node_selector.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="scheduling-debug"
+namespace="inventory-team"
 deployment="inventory-worker"
 
 dump_debug() {

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="storage-debug"
+namespace="ledger-services"
 deployment="ledger-api"
 pvc="ledger-data"
 pv="infra-bench-ledger-data"

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n storage-debug get deployment ledger-api >/dev/null 2>&1; then
+    || kubectl -n ledger-services get deployment ledger-api >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/environment/workspace/bootstrap/storage.yaml
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/environment/workspace/bootstrap/storage.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: storage-debug
+  name: ledger-services
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: storage-debug
+  namespace: ledger-services
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: storage-debug
+  namespace: ledger-services
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: storage-debug
+  namespace: ledger-services
 rules:
   - apiGroups: [""]
     resources:
@@ -50,11 +50,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: storage-debug
+  namespace: ledger-services
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: storage-debug
+    namespace: ledger-services
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -63,7 +63,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-storage-reader-storage-debug
+  name: infra-bench-storage-reader-ledger-services
 rules:
   - apiGroups: [""]
     resources: ["nodes", "persistentvolumes"]
@@ -72,15 +72,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-storage-reader-storage-debug
+  name: infra-bench-storage-reader-ledger-services
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: storage-debug
+    namespace: ledger-services
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-storage-reader-storage-debug
+  name: infra-bench-storage-reader-ledger-services
 ---
 apiVersion: v1
 kind: PersistentVolume
@@ -103,7 +103,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ledger-data
-  namespace: storage-debug
+  namespace: ledger-services
   labels:
     app: ledger-api
 spec:
@@ -119,7 +119,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ledger-api
-  namespace: storage-debug
+  namespace: ledger-services
   labels:
     app: ledger-api
 spec:
@@ -157,7 +157,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: storage-debug
+  namespace: ledger-services
 data:
   deployment_uid: ""
   pvc_uid: ""

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/instruction.md
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `ledger-api` Deployment in the `storage-debug` namespace cannot start its
+The `ledger-api` Deployment in the `ledger-services` namespace cannot start its
 pod because its volume references a PersistentVolumeClaim name that does not
 exist. The intended PVC already exists and is bound.
 

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="storage-debug"
+namespace="ledger-services"
 deployment="ledger-api"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/fix-pvc-mount-claim/tests/test_pvc_mount.sh
+++ b/datasets/kubernetes-core/fix-pvc-mount-claim/tests/test_pvc_mount.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="storage-debug"
+namespace="ledger-services"
 deployment="ledger-api"
 pvc="ledger-data"
 pv="infra-bench-ledger-data"

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="quirky-debug"
+namespace="glyph-platform"
 deployment="glyph-cache"
 service="glyph-cache"
 agent_secret="infra-bench-agent-token"

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n quirky-debug get deployment glyph-cache >/dev/null 2>&1; then
+    || kubectl -n glyph-platform get deployment glyph-cache >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/environment/workspace/bootstrap/app.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: quirky-debug
+  name: glyph-platform
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: quirky-debug
+  namespace: glyph-platform
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: quirky-debug
+  namespace: glyph-platform
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: quirky-debug
+  namespace: glyph-platform
 rules:
   - apiGroups: [""]
     resources:
@@ -43,11 +43,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: quirky-debug
+  namespace: glyph-platform
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: quirky-debug
+    namespace: glyph-platform
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: glyph-cache
-  namespace: quirky-debug
+  namespace: glyph-platform
   labels:
     app: glyph-cache
 spec:
@@ -97,7 +97,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: glyph-cache
-  namespace: quirky-debug
+  namespace: glyph-platform
 spec:
   selector:
     app: glyph-cache
@@ -110,7 +110,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: quirky-debug
+  namespace: glyph-platform
 data:
   deployment_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/instruction.md
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `glyph-cache` app in namespace `quirky-debug` is running, but its pods never
+The `glyph-cache` app in namespace `glyph-platform` is running, but its pods never
 become Ready. This unfamiliar app exposes a nonstandard health endpoint, while
 the Deployment readiness probe still checks a conventional path.
 

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="quirky-debug"
+namespace="glyph-platform"
 deployment="glyph-cache"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/fix-quirky-health-endpoint/tests/test_quirky_health_endpoint.sh
+++ b/datasets/kubernetes-core/fix-quirky-health-endpoint/tests/test_quirky_health_endpoint.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="quirky-debug"
+namespace="glyph-platform"
 deployment="glyph-cache"
 service="glyph-cache"
 

--- a/datasets/kubernetes-core/fix-restricted-security-context/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-restricted-security-context/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="security-debug"
+namespace="billing-team"
 deployment="reporting"
 service="reporting"
 agent_secret="infra-bench-agent-token"

--- a/datasets/kubernetes-core/fix-restricted-security-context/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-restricted-security-context/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n security-debug get deployment reporting >/dev/null 2>&1; then
+    || kubectl -n billing-team get deployment reporting >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-restricted-security-context/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/fix-restricted-security-context/environment/workspace/bootstrap/app.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: security-debug
+  name: billing-team
   labels:
     pod-security.kubernetes.io/enforce: restricted
     pod-security.kubernetes.io/enforce-version: latest
@@ -12,13 +12,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: security-debug
+  namespace: billing-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: security-debug
+  namespace: billing-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -26,7 +26,7 @@ type: kubernetes.io/service-account-token
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-namespace-reader-security-debug
+  name: infra-bench-namespace-reader-billing-team
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
@@ -35,21 +35,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-namespace-reader-security-debug
+  name: infra-bench-namespace-reader-billing-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: security-debug
+    namespace: billing-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-namespace-reader-security-debug
+  name: infra-bench-namespace-reader-billing-team
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: security-debug
+  namespace: billing-team
 rules:
   - apiGroups: [""]
     resources:
@@ -70,11 +70,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: security-debug
+  namespace: billing-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: security-debug
+    namespace: billing-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -84,7 +84,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reporting
-  namespace: security-debug
+  namespace: billing-team
   labels:
     app: reporting
 spec:
@@ -134,7 +134,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: reporting
-  namespace: security-debug
+  namespace: billing-team
 spec:
   selector:
     app: reporting
@@ -147,7 +147,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: security-debug
+  namespace: billing-team
 data:
   deployment_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/fix-restricted-security-context/instruction.md
+++ b/datasets/kubernetes-core/fix-restricted-security-context/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `security-debug` namespace intentionally enforces restricted Pod Security.
+The `billing-team` namespace intentionally enforces restricted Pod Security.
 The `reporting` Deployment cannot create a pod because one required
 securityContext field is missing.
 

--- a/datasets/kubernetes-core/fix-restricted-security-context/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-restricted-security-context/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="security-debug"
+namespace="billing-team"
 deployment="reporting"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/fix-restricted-security-context/tests/test_security_context.sh
+++ b/datasets/kubernetes-core/fix-restricted-security-context/tests/test_security_context.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="security-debug"
+namespace="billing-team"
 deployment="reporting"
 service="reporting"
 

--- a/datasets/kubernetes-core/fix-service-dns-name/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-service-dns-name/environment/scripts/bootstrap-cluster
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-client_namespace="dns-debug"
-backend_namespace="backend-services"
+client_namespace="checkout-team"
+backend_namespace="orders-team"
 client_deployment="checkout-client"
 backend_deployment="orders-api"
 backend_service="orders-api"
@@ -33,7 +33,7 @@ for _ in $(seq 1 120); do
   fi
 
   if ! kubectl -n "$client_namespace" exec "$client_pod" -- wget -qO- -T 2 http://orders-api.default.svc.cluster.local >/tmp/wrong-dns.out 2>/tmp/wrong-dns.err \
-    && kubectl -n "$client_namespace" exec "$client_pod" -- wget -qO- -T 2 http://orders-api.backend-services.svc.cluster.local >/tmp/correct-dns.out 2>/tmp/correct-dns.err; then
+    && kubectl -n "$client_namespace" exec "$client_pod" -- wget -qO- -T 2 http://orders-api.orders-team.svc.cluster.local >/tmp/correct-dns.out 2>/tmp/correct-dns.err; then
     break
   fi
 
@@ -52,7 +52,7 @@ if kubectl -n "$client_namespace" exec "$client_pod" -- wget -qO- -T 2 http://or
   exit 1
 fi
 
-if ! kubectl -n "$client_namespace" exec "$client_pod" -- wget -qO- -T 2 http://orders-api.backend-services.svc.cluster.local >/tmp/correct-dns.out 2>/tmp/correct-dns.err; then
+if ! kubectl -n "$client_namespace" exec "$client_pod" -- wget -qO- -T 2 http://orders-api.orders-team.svc.cluster.local >/tmp/correct-dns.out 2>/tmp/correct-dns.err; then
   echo "expected the correct backend Service DNS name to work before starting the task" >&2
   cat /tmp/correct-dns.err >&2 || true
   exit 1

--- a/datasets/kubernetes-core/fix-service-dns-name/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-service-dns-name/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n dns-debug get deployment checkout-client >/dev/null 2>&1; then
+    || kubectl -n checkout-team get deployment checkout-client >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-service-dns-name/environment/workspace/bootstrap/dns.yaml
+++ b/datasets/kubernetes-core/fix-service-dns-name/environment/workspace/bootstrap/dns.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: dns-debug
+  name: checkout-team
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: backend-services
+  name: orders-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: dns-debug
+  namespace: checkout-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: dns-debug
+  namespace: checkout-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -27,7 +27,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: dns-debug
+  namespace: checkout-team
 rules:
   - apiGroups: [""]
     resources:
@@ -59,11 +59,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: dns-debug
+  namespace: checkout-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: dns-debug
+    namespace: checkout-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -73,7 +73,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-backend-reader
-  namespace: backend-services
+  namespace: orders-team
 rules:
   - apiGroups: [""]
     resources: ["endpoints", "events", "pods", "pods/log", "services"]
@@ -89,11 +89,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-backend-reader
-  namespace: backend-services
+  namespace: orders-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: dns-debug
+    namespace: checkout-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -102,7 +102,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-namespace-reader-dns-debug
+  name: infra-bench-namespace-reader-checkout-team
 rules:
   - apiGroups: [""]
     resources: ["namespaces"]
@@ -111,21 +111,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-namespace-reader-dns-debug
+  name: infra-bench-namespace-reader-checkout-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: dns-debug
+    namespace: checkout-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-namespace-reader-dns-debug
+  name: infra-bench-namespace-reader-checkout-team
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-api
-  namespace: backend-services
+  namespace: orders-team
   labels:
     app: orders-api
 spec:
@@ -149,7 +149,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: orders-api
-  namespace: backend-services
+  namespace: orders-team
   labels:
     app: orders-api
 spec:
@@ -164,7 +164,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: checkout-client
-  namespace: dns-debug
+  namespace: checkout-team
   labels:
     app: checkout-client
 spec:
@@ -196,7 +196,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: dns-debug
+  namespace: checkout-team
 data:
   client_deployment_uid: ""
   backend_deployment_uid: ""

--- a/datasets/kubernetes-core/fix-service-dns-name/instruction.md
+++ b/datasets/kubernetes-core/fix-service-dns-name/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `checkout-client` Deployment in the `dns-debug` namespace cannot reach its
+The `checkout-client` Deployment in the `checkout-team` namespace cannot reach its
 backend because its configured in-cluster Service DNS name points to the wrong
 namespace. The backend Service already exists in the cluster.
 

--- a/datasets/kubernetes-core/fix-service-dns-name/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-service-dns-name/solution/solve.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="dns-debug"
+namespace="checkout-team"
 deployment="checkout-client"
 
 kubectl -n "$namespace" set env deployment/"$deployment" \
-  BACKEND_URL=http://orders-api.backend-services.svc.cluster.local
+  BACKEND_URL=http://orders-api.orders-team.svc.cluster.local
 
 kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=180s

--- a/datasets/kubernetes-core/fix-service-dns-name/tests/test_service_dns.sh
+++ b/datasets/kubernetes-core/fix-service-dns-name/tests/test_service_dns.sh
@@ -3,12 +3,12 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-client_namespace="dns-debug"
-backend_namespace="backend-services"
+client_namespace="checkout-team"
+backend_namespace="orders-team"
 client_deployment="checkout-client"
 backend_deployment="orders-api"
 backend_service="orders-api"
-expected_backend_url="http://orders-api.backend-services.svc.cluster.local"
+expected_backend_url="http://orders-api.orders-team.svc.cluster.local"
 wrong_backend_url="http://orders-api.default.svc.cluster.local"
 
 dump_debug() {

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="operator-debug"
+namespace="search-team"
 crd="widgets.platform.infra-bench.dev"
 controller="widget-controller"
 resource="search-index"

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n operator-debug get widget search-index >/dev/null 2>&1; then
+    || kubectl -n search-team get widget search-index >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/workspace/bootstrap/crd.yaml
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/workspace/bootstrap/crd.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: operator-debug
+  name: search-team
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/datasets/kubernetes-core/fix-simple-cr-field/environment/workspace/bootstrap/operator.yaml
+++ b/datasets/kubernetes-core/fix-simple-cr-field/environment/workspace/bootstrap/operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: operator-debug
+  name: search-team
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -42,13 +42,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: operator-debug
+  namespace: search-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: operator-debug
+  namespace: search-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -57,12 +57,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: widget-controller
-  namespace: operator-debug
+  namespace: search-team
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-crd-reader-operator-debug
+  name: infra-bench-crd-reader-search-team
 rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
@@ -71,15 +71,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-crd-reader-operator-debug
+  name: infra-bench-crd-reader-search-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: operator-debug
+    namespace: search-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-crd-reader-operator-debug
+  name: infra-bench-crd-reader-search-team
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -100,7 +100,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: widget-controller
-    namespace: operator-debug
+    namespace: search-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -110,7 +110,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: operator-debug
+  namespace: search-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "services"]
@@ -133,11 +133,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: operator-debug
+  namespace: search-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: operator-debug
+    namespace: search-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -147,7 +147,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: widget-controller
-  namespace: operator-debug
+  namespace: search-team
   labels:
     app: widget-controller
 spec:
@@ -169,11 +169,11 @@ spec:
             - -c
             - |
               while true; do
-                mode="$(kubectl -n operator-debug get widget search-index -o jsonpath='{.spec.mode}' 2>/dev/null || true)"
+                mode="$(kubectl -n search-team get widget search-index -o jsonpath='{.spec.mode}' 2>/dev/null || true)"
                 if [ "$mode" = "active" ] || [ "$mode" = "passive" ]; then
-                  kubectl -n operator-debug patch widget search-index --subresource=status --type merge --patch '{"status":{"observedMode":"'"$mode"'","conditions":[{"type":"Ready","status":"True","reason":"Reconciled","message":"Widget mode is supported"}]}}' >/dev/null 2>&1 || true
+                  kubectl -n search-team patch widget search-index --subresource=status --type merge --patch '{"status":{"observedMode":"'"$mode"'","conditions":[{"type":"Ready","status":"True","reason":"Reconciled","message":"Widget mode is supported"}]}}' >/dev/null 2>&1 || true
                 elif [ -n "$mode" ]; then
-                  kubectl -n operator-debug patch widget search-index --subresource=status --type merge --patch '{"status":{"observedMode":"'"$mode"'","conditions":[{"type":"Ready","status":"False","reason":"InvalidMode","message":"Unsupported mode '"$mode"'; valid values are active or passive"}]}}' >/dev/null 2>&1 || true
+                  kubectl -n search-team patch widget search-index --subresource=status --type merge --patch '{"status":{"observedMode":"'"$mode"'","conditions":[{"type":"Ready","status":"False","reason":"InvalidMode","message":"Unsupported mode '"$mode"'; valid values are active or passive"}]}}' >/dev/null 2>&1 || true
                 fi
                 sleep 2
               done
@@ -182,7 +182,7 @@ apiVersion: platform.infra-bench.dev/v1alpha1
 kind: Widget
 metadata:
   name: search-index
-  namespace: operator-debug
+  namespace: search-team
   finalizers:
     - platform.infra-bench.dev/finalizer
 spec:
@@ -192,7 +192,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: operator-debug
+  namespace: search-team
 data:
   custom_resource_uid: ""
   crd_uid: ""

--- a/datasets/kubernetes-core/fix-simple-cr-field/instruction.md
+++ b/datasets/kubernetes-core/fix-simple-cr-field/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `search-index` custom resource in the `operator-debug` namespace is not
+The `search-index` custom resource in the `search-team` namespace is not
 reconciling because one spec field contains a value the installed controller
 does not accept.
 

--- a/datasets/kubernetes-core/fix-simple-cr-field/solution/solve.sh
+++ b/datasets/kubernetes-core/fix-simple-cr-field/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="operator-debug"
+namespace="search-team"
 
 kubectl -n "$namespace" patch widget search-index \
   --type merge \

--- a/datasets/kubernetes-core/fix-simple-cr-field/tests/test_custom_resource.sh
+++ b/datasets/kubernetes-core/fix-simple-cr-field/tests/test_custom_resource.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="operator-debug"
+namespace="search-team"
 crd="widgets.platform.infra-bench.dev"
 controller="widget-controller"
 resource="search-index"

--- a/datasets/kubernetes-core/reconnect-frontend-api/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/reconnect-frontend-api/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="dependency-debug"
+namespace="customer-portal"
 api_deployment="api"
 frontend_deployment="frontend"
 agent_secret="infra-bench-agent-token"

--- a/datasets/kubernetes-core/reconnect-frontend-api/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/reconnect-frontend-api/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n dependency-debug get deployment frontend >/dev/null 2>&1; then
+    || kubectl -n customer-portal get deployment frontend >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/reconnect-frontend-api/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/reconnect-frontend-api/environment/workspace/bootstrap/app.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: dependency-debug
+  name: customer-portal
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: dependency-debug
+  namespace: customer-portal
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: dependency-debug
+  namespace: customer-portal
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: dependency-debug
+  namespace: customer-portal
 rules:
   - apiGroups: [""]
     resources:
@@ -43,11 +43,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: dependency-debug
+  namespace: customer-portal
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: dependency-debug
+    namespace: customer-portal
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,7 +57,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api
-  namespace: dependency-debug
+  namespace: customer-portal
   labels:
     app: api
 spec:
@@ -98,7 +98,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api
-  namespace: dependency-debug
+  namespace: customer-portal
 spec:
   selector:
     app: api
@@ -111,7 +111,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
-  namespace: dependency-debug
+  namespace: customer-portal
   labels:
     app: frontend
 spec:
@@ -160,7 +160,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
-  namespace: dependency-debug
+  namespace: customer-portal
 spec:
   selector:
     app: frontend
@@ -173,7 +173,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: dependency-debug
+  namespace: customer-portal
 data:
   api_deployment_uid: ""
   frontend_deployment_uid: ""

--- a/datasets/kubernetes-core/reconnect-frontend-api/instruction.md
+++ b/datasets/kubernetes-core/reconnect-frontend-api/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The API workload in namespace `dependency-debug` is healthy, but the
+The API workload in namespace `customer-portal` is healthy, but the
 `frontend` Deployment cannot reach it because the frontend dependency URL
 points at the wrong Service name.
 

--- a/datasets/kubernetes-core/reconnect-frontend-api/solution/solve.sh
+++ b/datasets/kubernetes-core/reconnect-frontend-api/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="dependency-debug"
+namespace="customer-portal"
 
 kubectl -n "$namespace" set env deployment/frontend API_URL=http://api:8080
 kubectl -n "$namespace" rollout status deployment/frontend --timeout=180s

--- a/datasets/kubernetes-core/reconnect-frontend-api/tests/test_frontend_api.sh
+++ b/datasets/kubernetes-core/reconnect-frontend-api/tests/test_frontend_api.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="dependency-debug"
+namespace="customer-portal"
 api="api"
 frontend="frontend"
 

--- a/datasets/kubernetes-core/repair-ingress-backend-port/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="ingress-debug"
+namespace="support-team"
 deployment="storefront"
 service="storefront"
 ingress="storefront"

--- a/datasets/kubernetes-core/repair-ingress-backend-port/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n ingress-debug get ingress storefront >/dev/null 2>&1; then
+    || kubectl -n support-team get ingress storefront >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/repair-ingress-backend-port/environment/workspace/bootstrap/ingress.yaml
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/environment/workspace/bootstrap/ingress.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: ingress-debug
+  name: support-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: ingress-debug
+  namespace: support-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: ingress-debug
+  namespace: support-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: ingress-debug
+  namespace: support-team
 rules:
   - apiGroups: [""]
     resources:
@@ -58,11 +58,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: ingress-debug
+  namespace: support-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: ingress-debug
+    namespace: support-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -71,7 +71,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-ingressclass-reader-ingress-debug
+  name: infra-bench-ingressclass-reader-support-team
 rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingressclasses"]
@@ -80,15 +80,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-ingressclass-reader-ingress-debug
+  name: infra-bench-ingressclass-reader-support-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: ingress-debug
+    namespace: support-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-ingressclass-reader-ingress-debug
+  name: infra-bench-ingressclass-reader-support-team
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -111,7 +111,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: ingress-debug
+    namespace: support-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -121,7 +121,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: storefront
-  namespace: ingress-debug
+  namespace: support-team
   labels:
     app: storefront
 spec:
@@ -145,7 +145,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: storefront
-  namespace: ingress-debug
+  namespace: support-team
   labels:
     app: storefront
 spec:
@@ -160,7 +160,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: storefront-tls
-  namespace: ingress-debug
+  namespace: support-team
 type: kubernetes.io/tls
 data:
   tls.crt: ZHVtbXktY2VydA==
@@ -170,7 +170,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: storefront
-  namespace: ingress-debug
+  namespace: support-team
 spec:
   ingressClassName: traefik
   tls:
@@ -193,7 +193,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingress-client
-  namespace: ingress-debug
+  namespace: support-team
   labels:
     app: ingress-client
 spec:
@@ -215,7 +215,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: ingress-debug
+  namespace: support-team
 data:
   ingress_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/repair-ingress-backend-port/solution/solve.sh
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="ingress-debug"
+namespace="support-team"
 ingress="storefront"
 
 kubectl -n "$namespace" patch ingress "$ingress" \

--- a/datasets/kubernetes-core/repair-ingress-backend-port/tests/test_ingress_backend.sh
+++ b/datasets/kubernetes-core/repair-ingress-backend-port/tests/test_ingress_backend.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="ingress-debug"
+namespace="support-team"
 deployment="storefront"
 service="storefront"
 ingress="storefront"

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="readiness-debug"
+namespace="checkout-services"
 deployment="checkout-api"
 agent_secret="infra-bench-agent-token"
 

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n readiness-debug get deployment checkout-api >/dev/null 2>&1; then
+    || kubectl -n checkout-services get deployment checkout-api >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/repair-readiness-probe-path/environment/workspace/bootstrap/readiness.yaml
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/environment/workspace/bootstrap/readiness.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: readiness-debug
+  name: checkout-services
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: checkout-content
-  namespace: readiness-debug
+  namespace: checkout-services
 data:
   readyz: |
     ok
@@ -16,13 +16,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: readiness-debug
+  namespace: checkout-services
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: readiness-debug
+  namespace: checkout-services
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -31,7 +31,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: readiness-debug
+  namespace: checkout-services
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log"]
@@ -51,11 +51,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: readiness-debug
+  namespace: checkout-services
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: readiness-debug
+    namespace: checkout-services
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -65,7 +65,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: checkout-api
-  namespace: readiness-debug
+  namespace: checkout-services
   labels:
     app: checkout-api
 spec:
@@ -105,6 +105,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: readiness-debug
+  namespace: checkout-services
 data:
   deployment_uid: ""

--- a/datasets/kubernetes-core/repair-readiness-probe-path/instruction.md
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `readiness-debug` namespace contains a Deployment named `checkout-api`.
+The `checkout-services` namespace contains a Deployment named `checkout-api`.
 Its pods are running, but they never become Ready, so the Deployment rollout
 does not complete.
 

--- a/datasets/kubernetes-core/repair-readiness-probe-path/solution/solve.sh
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="readiness-debug"
+namespace="checkout-services"
 deployment="checkout-api"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/repair-readiness-probe-path/tests/test_readiness_probe.sh
+++ b/datasets/kubernetes-core/repair-readiness-probe-path/tests/test_readiness_probe.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="readiness-debug"
+namespace="checkout-services"
 deployment="checkout-api"
 
 dump_debug() {

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="upgrade-debug"
+namespace="edge-team"
 deployment="legacy-web"
 service="legacy-web"
 secret="legacy-web-tls"

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n upgrade-debug get deployment legacy-web >/dev/null 2>&1; then
+    || kubectl -n edge-team get deployment legacy-web >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/workspace/app/ingress.yaml
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/workspace/app/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: legacy-web
-  namespace: upgrade-debug
+  namespace: edge-team
 spec:
   ingressClassName: traefik
   tls:

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/environment/workspace/bootstrap/app.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: upgrade-debug
+  name: edge-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: upgrade-debug
+  namespace: edge-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: upgrade-debug
+  namespace: edge-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: upgrade-debug
+  namespace: edge-team
 rules:
   - apiGroups: [""]
     resources:
@@ -54,11 +54,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: upgrade-debug
+  namespace: edge-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: upgrade-debug
+    namespace: edge-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -67,7 +67,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-ingressclass-reader-upgrade-debug
+  name: infra-bench-ingressclass-reader-edge-team
 rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["ingressclasses"]
@@ -76,15 +76,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-ingressclass-reader-upgrade-debug
+  name: infra-bench-ingressclass-reader-edge-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: upgrade-debug
+    namespace: edge-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-ingressclass-reader-upgrade-debug
+  name: infra-bench-ingressclass-reader-edge-team
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -107,7 +107,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: upgrade-debug
+    namespace: edge-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -117,7 +117,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: legacy-web
-  namespace: upgrade-debug
+  namespace: edge-team
   labels:
     app: legacy-web
 spec:
@@ -141,7 +141,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: legacy-web
-  namespace: upgrade-debug
+  namespace: edge-team
   labels:
     app: legacy-web
 spec:
@@ -156,7 +156,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: legacy-web-tls
-  namespace: upgrade-debug
+  namespace: edge-team
 type: kubernetes.io/tls
 data:
   tls.crt: ZHVtbXktY2VydA==
@@ -166,7 +166,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ingress-client
-  namespace: upgrade-debug
+  namespace: edge-team
   labels:
     app: ingress-client
 spec:
@@ -188,7 +188,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: upgrade-debug
+  namespace: edge-team
 data:
   service_uid: ""
   deployment_uid: ""

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/solution/solve.sh
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/solution/solve.sh
@@ -8,7 +8,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: legacy-web
-  namespace: upgrade-debug
+  namespace: edge-team
 spec:
   ingressClassName: traefik
   tls:

--- a/datasets/kubernetes-core/replace-deprecated-ingress-api/tests/test_ingress_api.sh
+++ b/datasets/kubernetes-core/replace-deprecated-ingress-api/tests/test_ingress_api.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="upgrade-debug"
+namespace="edge-team"
 deployment="legacy-web"
 service="legacy-web"
 ingress="legacy-web"

--- a/datasets/kubernetes-core/restore-missing-configmap/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/restore-missing-configmap/environment/scripts/bootstrap-cluster
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source_namespace="catalog-source"
-target_namespace="catalog-migrated"
+source_namespace="catalog-primary"
+target_namespace="catalog-secondary"
 deployment="catalog-web"
 service="catalog-web"
 configmap="app-config"

--- a/datasets/kubernetes-core/restore-missing-configmap/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/restore-missing-configmap/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n catalog-migrated get deployment catalog-web >/dev/null 2>&1; then
+    || kubectl -n catalog-secondary get deployment catalog-web >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/restore-missing-configmap/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/restore-missing-configmap/environment/workspace/bootstrap/app.yaml
@@ -1,24 +1,24 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: catalog-source
+  name: catalog-primary
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: catalog-migrated
+  name: catalog-secondary
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: catalog-migrated
+  namespace: catalog-secondary
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: catalog-migrated
+  namespace: catalog-secondary
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: app-config
-  namespace: catalog-source
+  namespace: catalog-primary
 data:
   APP_MODE: migrated
   FEATURE_FLAG: search-v2
@@ -37,7 +37,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: source-config-reader
-  namespace: catalog-source
+  namespace: catalog-primary
 rules:
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -47,11 +47,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: source-config-reader
-  namespace: catalog-source
+  namespace: catalog-primary
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: catalog-migrated
+    namespace: catalog-secondary
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -61,7 +61,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: catalog-migrated
+  namespace: catalog-secondary
 rules:
   - apiGroups: [""]
     resources:
@@ -81,11 +81,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: catalog-migrated
+  namespace: catalog-secondary
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: catalog-migrated
+    namespace: catalog-secondary
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -95,7 +95,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalog-web
-  namespace: catalog-migrated
+  namespace: catalog-secondary
   labels:
     app: catalog-web
 spec:
@@ -139,7 +139,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: catalog-web
-  namespace: catalog-migrated
+  namespace: catalog-secondary
 spec:
   selector:
     app: catalog-web
@@ -152,7 +152,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: catalog-migrated
+  namespace: catalog-secondary
 data:
   deployment_uid: ""
   service_uid: ""

--- a/datasets/kubernetes-core/restore-missing-configmap/instruction.md
+++ b/datasets/kubernetes-core/restore-missing-configmap/instruction.md
@@ -6,21 +6,21 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-A workload was migrated from the `catalog-source` namespace into
-`catalog-migrated`, but one required ConfigMap was not copied. The migrated pod
+A workload was migrated from the `catalog-primary` namespace into
+`catalog-secondary`, but one required ConfigMap was not copied. The migrated pod
 cannot start because its referenced ConfigMap is missing from the target
 namespace.
 
-Repair the live cluster so the migrated workload starts in `catalog-migrated`.
+Repair the live cluster so the migrated workload starts in `catalog-secondary`.
 
 Constraints:
 
 - Use `kubectl` to inspect pod events, the target namespace, and the source
   namespace before changing anything.
-- Recreate the missing ConfigMap in `catalog-migrated` from the source
+- Recreate the missing ConfigMap in `catalog-secondary` from the source
   namespace data.
 - Keep the existing `catalog-web` Deployment and Service in
-  `catalog-migrated`; do not delete or recreate them.
+  `catalog-secondary`; do not delete or recreate them.
 - Do not edit the Deployment to hardcode environment variables or point at a
   different ConfigMap.
 - Do not modify source namespace resources or create replacement workloads,

--- a/datasets/kubernetes-core/restore-missing-configmap/solution/solve.sh
+++ b/datasets/kubernetes-core/restore-missing-configmap/solution/solve.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-source_namespace="catalog-source"
-target_namespace="catalog-migrated"
+source_namespace="catalog-primary"
+target_namespace="catalog-secondary"
 configmap="app-config"
 
 app_mode="$(kubectl -n "$source_namespace" get configmap "$configmap" -o jsonpath='{.data.APP_MODE}')"

--- a/datasets/kubernetes-core/restore-missing-configmap/tests/test_missing_configmap.sh
+++ b/datasets/kubernetes-core/restore-missing-configmap/tests/test_missing_configmap.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-source_namespace="catalog-source"
-target_namespace="catalog-migrated"
+source_namespace="catalog-primary"
+target_namespace="catalog-secondary"
 deployment="catalog-web"
 service="catalog-web"
 configmap="app-config"

--- a/datasets/kubernetes-core/rightsize-cpu-request/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/rightsize-cpu-request/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="cpu-debug"
+namespace="reporting-team"
 deployment="report-api"
 agent_secret="infra-bench-agent-token"
 

--- a/datasets/kubernetes-core/rightsize-cpu-request/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/rightsize-cpu-request/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n cpu-debug get deployment report-api >/dev/null 2>&1; then
+    || kubectl -n reporting-team get deployment report-api >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/rightsize-cpu-request/environment/workspace/bootstrap/cpu.yaml
+++ b/datasets/kubernetes-core/rightsize-cpu-request/environment/workspace/bootstrap/cpu.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: cpu-debug
+  name: reporting-team
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: cpu-debug
+  namespace: reporting-team
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: cpu-debug
+  namespace: reporting-team
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: cpu-debug
+  namespace: reporting-team
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "services"]
@@ -42,11 +42,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: cpu-debug
+  namespace: reporting-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: cpu-debug
+    namespace: reporting-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,7 +55,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-node-reader-cpu-debug
+  name: infra-bench-node-reader-reporting-team
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -64,21 +64,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-node-reader-cpu-debug
+  name: infra-bench-node-reader-reporting-team
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: cpu-debug
+    namespace: reporting-team
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-node-reader-cpu-debug
+  name: infra-bench-node-reader-reporting-team
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: report-api
-  namespace: cpu-debug
+  namespace: reporting-team
   labels:
     app: report-api
   annotations:
@@ -111,7 +111,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: cpu-debug
+  namespace: reporting-team
 data:
   deployment_uid: ""
   node_name: ""

--- a/datasets/kubernetes-core/rightsize-cpu-request/instruction.md
+++ b/datasets/kubernetes-core/rightsize-cpu-request/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `report-api` Deployment in the `cpu-debug` namespace cannot schedule its
+The `report-api` Deployment in the `reporting-team` namespace cannot schedule its
 pods because the container CPU request is far larger than the available node
 capacity.
 

--- a/datasets/kubernetes-core/rightsize-cpu-request/solution/solve.sh
+++ b/datasets/kubernetes-core/rightsize-cpu-request/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="cpu-debug"
+namespace="reporting-team"
 deployment="report-api"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/rightsize-cpu-request/tests/test_cpu_request.sh
+++ b/datasets/kubernetes-core/rightsize-cpu-request/tests/test_cpu_request.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="cpu-debug"
+namespace="reporting-team"
 deployment="report-api"
 
 dump_debug() {

--- a/datasets/kubernetes-core/target-gpu-node-label/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/target-gpu-node-label/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="gpu-debug"
+namespace="vision-services"
 deployment="vision-worker"
 agent_secret="infra-bench-agent-token"
 

--- a/datasets/kubernetes-core/target-gpu-node-label/environment/scripts/prepare-kubeconfig
+++ b/datasets/kubernetes-core/target-gpu-node-label/environment/scripts/prepare-kubeconfig
@@ -21,7 +21,7 @@ fi
 
 for _ in $(seq 1 120); do
   if kubectl get --raw=/readyz >/dev/null 2>&1 \
-    || kubectl -n gpu-debug get deployment vision-worker >/dev/null 2>&1; then
+    || kubectl -n vision-services get deployment vision-worker >/dev/null 2>&1; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/target-gpu-node-label/environment/workspace/bootstrap/gpu.yaml
+++ b/datasets/kubernetes-core/target-gpu-node-label/environment/workspace/bootstrap/gpu.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: gpu-debug
+  name: vision-services
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: gpu-debug
+  namespace: vision-services
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: gpu-debug
+  namespace: vision-services
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: gpu-debug
+  namespace: vision-services
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log", "services"]
@@ -42,11 +42,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: gpu-debug
+  namespace: vision-services
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: gpu-debug
+    namespace: vision-services
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,7 +55,7 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: infra-bench-node-reader-gpu-debug
+  name: infra-bench-node-reader-vision-services
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -64,21 +64,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: infra-bench-node-reader-gpu-debug
+  name: infra-bench-node-reader-vision-services
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: gpu-debug
+    namespace: vision-services
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: infra-bench-node-reader-gpu-debug
+  name: infra-bench-node-reader-vision-services
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vision-worker
-  namespace: gpu-debug
+  namespace: vision-services
   labels:
     app: vision-worker
     workload: simulated-gpu
@@ -115,7 +115,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: gpu-debug
+  namespace: vision-services
 data:
   deployment_uid: ""
   node_name: ""

--- a/datasets/kubernetes-core/target-gpu-node-label/instruction.md
+++ b/datasets/kubernetes-core/target-gpu-node-label/instruction.md
@@ -6,7 +6,7 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The `vision-worker` Deployment in the `gpu-debug` namespace cannot schedule its
+The `vision-worker` Deployment in the `vision-services` namespace cannot schedule its
 pods because its simulated GPU node selector does not match the available
 accelerator node label.
 

--- a/datasets/kubernetes-core/target-gpu-node-label/solution/solve.sh
+++ b/datasets/kubernetes-core/target-gpu-node-label/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="gpu-debug"
+namespace="vision-services"
 deployment="vision-worker"
 
 kubectl -n "$namespace" patch deployment "$deployment" \

--- a/datasets/kubernetes-core/target-gpu-node-label/tests/test_gpu_label.sh
+++ b/datasets/kubernetes-core/target-gpu-node-label/tests/test_gpu_label.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="gpu-debug"
+namespace="vision-services"
 deployment="vision-worker"
 
 dump_debug() {

--- a/docs/task-design.md
+++ b/docs/task-design.md
@@ -30,6 +30,10 @@ agent is meant to see into `/app`. For local-cluster Kubernetes tasks, keep
 bootstrap-only assets and scripts out of the agent image; expose them through a
 separate bootstrap image or bootstrap-only mounts.
 
+For Kubernetes cluster state, choose neutral namespace names. Namespaces should
+look like plausible team, tenant, or application boundaries, not the task slug,
+failure mode, intended fix, or benchmark coverage area.
+
 ## 4. Generate the Canary
 
 Run:
@@ -52,6 +56,9 @@ Keep the prompt direct:
 - What not to do.
 
 Do not describe exact verifier assertions.
+
+For Kubernetes prompts, do not use namespace names that reveal the issue; keep
+them consistent with the neutral names in the starting cluster.
 
 ## 6. Write the Verifier
 

--- a/docs/task-rules/kubernetes.md
+++ b/docs/task-rules/kubernetes.md
@@ -11,6 +11,11 @@ Kubernetes is the first benchmark domain for `infra-bench`.
 - Include broken starting state in `environment/`, not in tests.
 - The verifier should check behavior or externally observable state, not just
   exact file diffs.
+- Use neutral Kubernetes namespace names in cluster state and prompts. Do not
+  name namespaces after the task slug, failure mode, intended fix, or coverage
+  area, such as `dns-debug`, `rbac-debug`, `readiness-debug`, or
+  `fix-selector`. Prefer plausible tenant, team, or application names that
+  help the agent orient without revealing the issue.
 - Avoid tasks that require privileged host access unless the dataset explicitly
   documents that environment class.
 
@@ -129,6 +134,8 @@ environment/
 A copyable skeleton lives in
 `docs/templates/kubernetes-local-cluster-task/`. Replace every `TODO_*`
 placeholder before moving it into `datasets/kubernetes-core/<task-name>`.
+Use `TODO_NEUTRAL_NAMESPACE` for a realistic namespace name that does not reveal
+the task category or bug.
 
 Use `bootstrap-cluster` to:
 

--- a/docs/templates/kubernetes-local-cluster-task/README.md
+++ b/docs/templates/kubernetes-local-cluster-task/README.md
@@ -15,3 +15,7 @@ The template follows the two-image convention:
 Before copying this template into `datasets/kubernetes-core/<task-name>`,
 replace all `TODO_*` placeholders, generate a fresh canary, and run the
 validation workflow documented in `docs/task-rules/kubernetes.md`.
+
+Choose a neutral value for `TODO_NEUTRAL_NAMESPACE`. The namespace should look
+like a plausible tenant, team, or application namespace, and must not include
+the task slug, failure mode, intended fix, or coverage-area hint.

--- a/docs/templates/kubernetes-local-cluster-task/environment/scripts/bootstrap-cluster
+++ b/docs/templates/kubernetes-local-cluster-task/environment/scripts/bootstrap-cluster
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="TODO_NAMESPACE"
+namespace="TODO_NEUTRAL_NAMESPACE"
 agent_secret="infra-bench-agent-token"
 
 prepare-kubeconfig

--- a/docs/templates/kubernetes-local-cluster-task/environment/workspace/bootstrap/app.yaml
+++ b/docs/templates/kubernetes-local-cluster-task/environment/workspace/bootstrap/app.yaml
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: TODO_NAMESPACE
+  name: TODO_NEUTRAL_NAMESPACE
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
-  namespace: TODO_NAMESPACE
+  namespace: TODO_NEUTRAL_NAMESPACE
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: infra-bench-agent-token
-  namespace: TODO_NAMESPACE
+  namespace: TODO_NEUTRAL_NAMESPACE
   annotations:
     kubernetes.io/service-account.name: infra-bench-agent
 type: kubernetes.io/service-account-token
@@ -22,7 +22,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: infra-bench-agent
-  namespace: TODO_NAMESPACE
+  namespace: TODO_NEUTRAL_NAMESPACE
 rules:
   - apiGroups: [""]
     resources: ["configmaps", "events", "pods", "pods/log"]
@@ -39,11 +39,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: infra-bench-agent
-  namespace: TODO_NAMESPACE
+  namespace: TODO_NEUTRAL_NAMESPACE
 subjects:
   - kind: ServiceAccount
     name: infra-bench-agent
-    namespace: TODO_NAMESPACE
+    namespace: TODO_NEUTRAL_NAMESPACE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -53,6 +53,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: infra-bench-baseline
-  namespace: TODO_NAMESPACE
+  namespace: TODO_NEUTRAL_NAMESPACE
 data:
   deployment_uid: ""

--- a/docs/templates/kubernetes-local-cluster-task/solution/solve.sh
+++ b/docs/templates/kubernetes-local-cluster-task/solution/solve.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="TODO_NAMESPACE"
+namespace="TODO_NEUTRAL_NAMESPACE"
 
 # TODO: implement the minimal oracle repair.
 kubectl -n "$namespace" get all

--- a/docs/templates/kubernetes-local-cluster-task/tests/test_task.sh
+++ b/docs/templates/kubernetes-local-cluster-task/tests/test_task.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 prepare-kubeconfig
 
-namespace="TODO_NAMESPACE"
+namespace="TODO_NEUTRAL_NAMESPACE"
 
 # TODO: verify semantic live-cluster state and reject shortcut fixes.
 kubectl -n "$namespace" get all


### PR DESCRIPTION
Rename the easy Kubernetes task namespaces so live cluster state no longer hints at the failure mode or intended fix.

The easy tasks previously used names such as `dns-debug`, `rbac-debug`, and `readiness-debug`, which could point agents toward the issue instead of requiring live diagnosis. This updates manifests, bootstrap scripts, instructions, oracle solutions, and verifier scripts to use neutral team, tenant, or application-style namespace names while keeping each task's resource relationships intact.

The Kubernetes task authoring docs and local-cluster template now call out neutral namespace naming explicitly, and the Kubernetes dataset digests are refreshed for the changed tasks.

Validation run locally: shell syntax checks for changed scripts, `./scripts/validate-structure.sh`, `python3 scripts/lint-kubernetes-rbac.py`, and `git diff --check`. I also ran the Harbor sync command required for `terraform-core`; for `kubernetes-core`, I used non-destructive local digest updates because `harbor sync` rewrites this working dataset directory from registry state.
