### PR TITLE
docs(tasks): Capture medium task design learnings

### DIFF
--- a/.agents/skills/design-infra-task/SKILL.md
+++ b/.agents/skills/design-infra-task/SKILL.md
@@ -49,7 +49,8 @@ Include these fields:
 - Scenario type
 - Environment class
 - Broken starting state
-- Agent-facing instruction outline
+- Agent-facing symptom and instruction outline
+- Hidden diagnostic concepts
 - Expected solution approach
 - Verifier strategy
 - Oracle solution strategy
@@ -68,6 +69,17 @@ Secret, RBAC, NetworkPolicy, storage, Job, or controller-generated state. Keep
 the outcome focused on one operator goal and identify the shortcut fixes the
 verifier must reject. Use `docs/templates/kubernetes-local-cluster-task/` as the
 starting environment shape for live-cluster medium and hard tasks.
+
+Separate the agent-facing symptom from the hidden diagnosis. For medium
+Kubernetes tasks, the prompt should usually be one short user report, such as
+"Users report that checkout records are failing." Do not include the root cause,
+failing Kubernetes primitive, useful log source, healthy distractors, or a note
+that unrelated resources exist. The design brief can record those details under
+hidden diagnostic concepts and verifier strategy instead.
+
+When adding noisy services or unrelated resources, describe them in the broken
+starting state only. They should make the cluster realistic without the prompt
+telling the agent what to ignore.
 
 ## Canary Requirement
 

--- a/.agents/skills/implement-infra-task/SKILL.md
+++ b/.agents/skills/implement-infra-task/SKILL.md
@@ -98,12 +98,18 @@ Before editing files, restate the contract in a short plan:
    - State the live outcome the operator must achieve.
    - State constraints and out-of-scope changes.
    - Do not reveal exact verifier assertions.
+   - For medium and hard tasks, keep the incident report symptom-only. Do not
+     name the root cause, Kubernetes primitive, useful evidence source, or
+     healthy distractor services unless the issue explicitly requires it.
 
 6. Write the verifier before tuning the oracle.
    - Verify behavior or semantic state, not formatting.
    - Write `/logs/verifier/reward.txt` or `/logs/verifier/reward.json`.
    - Dump useful debug output under `/logs/verifier` on failure.
    - Reject shortcut fixes described in the issue or implementation contract.
+   - Ensure verifier commands only require credentials available to the
+     verifier. Avoid impersonation, cluster-scope reads, or `auth can-i --as`
+     checks unless the task explicitly grants that authority.
 
 7. Write `solution/solve.sh`.
    - Keep it deterministic and boring.
@@ -128,6 +134,17 @@ workload plus Service, ConfigMap, Secret, RBAC, NetworkPolicy, storage, Job, or
 controller-generated resource. Keep the intended outcome bounded to one operator
 goal, and document which shortcut fixes the verifier rejects before tuning the
 oracle solution.
+
+Before finalizing a medium prompt, run this prompt-leak review:
+
+- Is the visible issue one short user-facing symptom?
+- Does the prompt avoid naming the root cause, subsystem, exact Kubernetes
+  concept, useful command output, or known failing field?
+- Does it avoid naming healthy or unrelated resources as distractors?
+- Does the namespace look neutral rather than like the task slug or fix?
+- Do constraints state policy without revealing the exact resource or field to
+  edit?
+- Does the verifier still enforce the hidden relationships and bypass checks?
 
 Local-cluster tasks should use separate cluster credentials:
 
@@ -180,6 +197,9 @@ Run a bypass review before final validation:
 - Can the agent create alternate workloads, Services, or standalone Pods?
 - Can the agent read bootstrap scripts or assets that reveal the answer?
 - Does the verifier check ownership relationships, not just counts?
+- Does the verifier reject broad "make it pass" shortcuts, such as disabling a
+  policy, granting cluster-admin, scaling to zero, or replacing the target
+  resource with a lookalike?
 
 For current k3s sidecar tasks, keep `allow_internet = true` unless an oracle run
 proves the agent can still reach the cluster with it disabled. This is a Harbor
@@ -211,6 +231,10 @@ python3 scripts/lint-kubernetes-rbac.py
 uvx --from harbor harbor sync datasets/<dataset-name>
 uvx --from harbor harbor run -p datasets/<dataset-name>/<task-name> -a oracle
 ```
+
+After Harbor sync, inspect the dataset manifest diff and keep only intended
+digest or metadata changes. Do not include unrelated TOML formatting churn in a
+task PR.
 
 For live Kubernetes tasks, run at least one real-agent trial before publishing
 when feasible:

--- a/docs/task-design.md
+++ b/docs/task-design.md
@@ -60,12 +60,29 @@ Do not describe exact verifier assertions.
 For Kubernetes prompts, do not use namespace names that reveal the issue; keep
 them consistent with the neutral names in the starting cluster.
 
+For medium and hard tasks, keep the agent-facing symptom intentionally sparse.
+The prompt may state the user-visible failure, but should not name the suspected
+root cause, exact Kubernetes concept, useful evidence source, or unrelated
+healthy services. For example, prefer "Users report that checkout records are
+failing" over "The billing API stopped becoming ready after database credential
+rotation." Do not tell the agent which resources are noise; add realistic
+distractor resources to the environment and let the agent decide what matters.
+
+Review constraints for answer leakage. A constraint that names the exact field
+or resource to change can make a medium task behave like an easy task. Prefer
+policy-level constraints, then let the verifier enforce the hidden relationships
+that matter.
+
 ## 6. Write the Verifier
 
 The verifier should answer: did the operator outcome happen?
 
 For most tasks, `tests/test.sh` can run a Python script and map exit code to
 `/logs/verifier/reward.txt`.
+
+Verifier logic may know the hidden diagnosis, but the task prompt should not.
+Use the verifier to reject bypasses such as replacement resources, broad
+privilege grants, disabled policies, or edits to verifier-trusted baselines.
 
 ## 7. Write the Oracle Solution
 

--- a/docs/task-rules/kubernetes.md
+++ b/docs/task-rules/kubernetes.md
@@ -49,6 +49,18 @@ not the number of files touched.
   capacity, migration or upgrade constraints, or validation that spans several
   controllers and runtime behaviors.
 
+Medium and hard prompts should usually be one short symptom plus the standard
+workspace and safety constraints. Do not name the failing subsystem, Kubernetes
+primitive, likely root cause, or exact evidence path unless that information
+would be visible to the real user who filed the incident. Avoid terms like
+`Secret`, `HPA`, `NetworkPolicy`, `nodeSelector`, `toleration`, `IngressClass`,
+or `PVC` in the prompt when those concepts are part of the diagnosis.
+
+Do not explain distractors. It is fine to include healthy documentation apps,
+reporting services, canaries, queues, or other cluster resources that are not
+part of the fix, but the prompt should not say that they are unrelated or
+healthy.
+
 For medium and hard `local_cluster` tasks, start from the same two-image
 environment pattern used by the easy tasks. Do not reintroduce a single image
 that copies bootstrap-only scripts or manifests into the agent runtime.
@@ -190,6 +202,12 @@ The agent prompt should make the live-cluster expectation explicit. Tell the
 agent to use `kubectl`, state that the cluster is already running, and describe
 the desired live state without revealing verifier assertions.
 
+When writing prompts for live-cluster medium tasks, audit for Kubernetes concept
+leaks. A sentence like "checkout records are failing" is usually enough. A
+sentence that mentions readiness, credential rotation, missing endpoints,
+metrics, logs, node labels, or a healthy side service often gives away the first
+diagnostic branch.
+
 ## Verifier Expectations
 
 Kubernetes verifiers should prefer semantic checks:
@@ -221,6 +239,12 @@ solutions:
 - Dump enough Kubernetes state on failure to debug the next run: namespace
   resources, relevant YAML, `describe` output, and recent events.
 
+Keep verifier permissions aligned with the kubeconfig available in the task
+runtime. Avoid checks such as `kubectl auth can-i --as ...`, cluster-scope
+reads, or impersonation unless the verifier credentials explicitly support
+them. Prefer direct semantic checks against the task namespace and the runtime
+behavior that proves the operator outcome.
+
 Keep verifier waits bounded and targeted. Wait for controller reconciliation
 where Kubernetes is eventually consistent, but fail with debug output instead of
 sleeping blindly.
@@ -244,6 +268,9 @@ Before adding a Kubernetes task to the dataset, run it in this order:
    python3 scripts/lint-kubernetes-rbac.py
    uvx --from harbor harbor sync datasets/kubernetes-core
    ```
+
+   Inspect `dataset.toml` after Harbor sync. Keep digest and intended task
+   metadata updates, but do not include unrelated formatting churn.
 
 3. Run the oracle agent to prove the scripted solution passes:
 


### PR DESCRIPTION
Capture the task design learnings from the recent Kubernetes medium task work in both repository docs and the infra task skills.

The updates clarify that medium and hard prompts should stay symptom-only, avoid naming distractors or root-cause Kubernetes primitives, and keep neutral namespaces and non-leaking constraints. They also add verifier guidance for hidden relationship checks, permission-aware verifier commands, bypass resistance, and avoiding unrelated Harbor sync TOML churn.

Validation run locally:
- `./scripts/validate-structure.sh`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/terraform-core`

No oracle run was needed because this PR changes documentation and skills only.
