### PR TITLE
ci: Use infra-bench runner for PR checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - kubeply-arm64-low-latency
+    - kubeply-infra-bench

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -17,8 +17,6 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=rhysd/actionlint
   ACTIONLINT_VERSION: v1.7.12
-  # renovate: datasource=github-releases depName=oven-sh/bun
-  BUN_VERSION: 1.3.10
   # renovate: datasource=npm depName=@taplo/cli
   TAPLO_VERSION: 0.7.0
 
@@ -67,22 +65,9 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on:
       group: kubeply-low-latency
-      labels: kubeply-arm64-low-latency
+      labels: kubeply-infra-bench
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          # renovate: datasource=pypi depName=uv
-          version: 0.11.7
-
-      - name: Install lint tools
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y jq shellcheck unzip
-          curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
-          echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
 
       - name: Validate file formatting and lint
         run: ./scripts/lint-files.sh


### PR DESCRIPTION
Route the heavy PR validation job to the dedicated kubeply-infra-bench runner label published from the homelab runner image work.

The fast-checks job now relies on the preinstalled infra-bench toolchain instead of reinstalling uv, jq, shellcheck, unzip, and Bun on every run. The actionlint job stays on the generic kubeply low-latency runner because it does not need the infra-bench image.

The actionlint configuration now includes the kubeply-infra-bench self-hosted runner label so workflow linting recognizes the new target.