### PR TITLE
docs(kubernetes): Tighten medium task prompts

### DIFF
--- a/datasets/kubernetes-core/clear-upgrade-blocking-apis/instruction.md
+++ b/datasets/kubernetes-core/clear-upgrade-blocking-apis/instruction.md
@@ -14,15 +14,14 @@ Constraints:
 
 - Use `kubectl` and the workspace files to inspect the preflight failure before
   changing anything.
-- Keep the existing namespace, workloads, Services, TLS material, generated
-  manifests, and working current-version routes in place.
-- Preserve names, selectors, hosts, paths, Service contracts, pod labels,
+- Keep the existing live resources, stored release assets, and working runtime
+  behavior in place.
+- Preserve resource identities, ownership, routing contracts, pod labels,
   container images, ports, and schedules.
 - Do not delete stored manifests instead of migrating them.
-- Do not delete or recreate existing workloads, Services, Secrets, current
-  routes, generated policy, or the namespace.
-- Do not create replacement workloads, alternate Services, standalone Pods, or
-  route bypasses.
+- Do not delete or recreate existing live resources or the namespace.
+- Do not create replacement workloads, alternate routes, standalone Pods, or
+  bypass resources.
 - Do not broaden RBAC, restart the cluster, or edit files outside `/app` unless
   needed for temporary notes.
 

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -129,7 +129,7 @@ digest = "sha256:0cd32f7297433cf24031308ffbfc78ed7e5779326269019b7dc4a332a8d5f12
 
 [[tasks]]
 name = "kubeply/prepare-node-drain-with-pdb"
-digest = "sha256:025a268c5e6e7be846ae7013a97424221e21ebe8268c5daf407ad7f33511ae52"
+digest = "sha256:78f15054154313a997b47750f9606f628ce8be5930b472b3769e010feda1988c"
 
 [[tasks]]
 name = "kubeply/repair-worker-hpa-scaling-inputs"

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -109,7 +109,7 @@ digest = "sha256:23035e2bf05bd4c283e44544b368d4771b1bb0cf77bc7b3fc8e4f2786dad9b0
 
 [[tasks]]
 name = "kubeply/recover-api-rollout-after-config-change"
-digest = "sha256:a5e2eb8955828edabdc722c4f42447904fee03a7ea27e0c60e187989f256c159"
+digest = "sha256:b3bc5e35224fb920c8399b310194e44136298e559c01b557b6fb9300ee238e64"
 
 [[tasks]]
 name = "kubeply/schedule-reporting-api-on-labeled-node"
@@ -125,11 +125,11 @@ digest = "sha256:cd780ecabe049ad97e65dbd4ae86434cca355f7c0756866d41bafda4017bebf
 
 [[tasks]]
 name = "kubeply/restore-metrics-controller-after-values-change"
-digest = "sha256:abf31c71782441c97c096d237492864e22d83cb4201cf0506e14ea995aa805c5"
+digest = "sha256:0cd32f7297433cf24031308ffbfc78ed7e5779326269019b7dc4a332a8d5f129"
 
 [[tasks]]
 name = "kubeply/prepare-node-drain-with-pdb"
-digest = "sha256:4ebc7a639c9f9e1a95bbd8f612fab773a7814ff9e77224a5371c199e5a21c525"
+digest = "sha256:025a268c5e6e7be846ae7013a97424221e21ebe8268c5daf407ad7f33511ae52"
 
 [[tasks]]
 name = "kubeply/repair-worker-hpa-scaling-inputs"
@@ -153,19 +153,19 @@ digest = "sha256:04214ec40c38fbcc77c6fc0a29d45bff277ab3fc18b272fb0f342878c4ff81c
 
 [[tasks]]
 name = "kubeply/clear-upgrade-blocking-apis"
-digest = "sha256:aa1955d20ac559b0322a950224be829589aaa0e2bef0f024af334b1ddda43664"
+digest = "sha256:790787ce06af11dd15cebe1b7909c7864892cd6d4844a27522ebc09be6ad4a02"
 
 [[tasks]]
 name = "kubeply/place-inference-canary-on-gpu-node"
-digest = "sha256:fde9620cd2163caa604319e8c201364e1ba5e8bca28a3a2cfd9aa3cfa839285c"
+digest = "sha256:b634d592c737e34208669b1c86ad53c5205560d936eb3cacc26b5d61835d27ce"
 
 [[tasks]]
 name = "kubeply/repair-sidecar-generated-config"
-digest = "sha256:15c740d6489abb53458a169b450d74415d34dc1d4cec0b027762f7aa9792aca5"
+digest = "sha256:426f288ea38ec9d7a8b22c14db28579020dd704a873dca610693cbf26d511a09"
 
 [[tasks]]
 name = "kubeply/repair-restricted-multi-container-pod"
-digest = "sha256:cc4e7d4ecec89d899f851a3b7cd68d9d131aeba821389b504cc7ab9d39d99033"
+digest = "sha256:aa21fbaa7a65648816295df74fc9790306b410cef4d74f8462f5e1e62788d610"
 
 [[tasks]]
 name = "kubeply/complete-staging-namespace-restore"
@@ -177,7 +177,7 @@ digest = "sha256:51daaf8a738933cc2c00e2f80c3744119cad80374942b3fe49b60ab600c5678
 
 [[tasks]]
 name = "kubeply/restore-grafana-logs-datasource"
-digest = "sha256:1b44a92ff9a87c21274c59eed3b74b805a8870dab08c67fb7937647cb4ded223"
+digest = "sha256:fac9b91bc25627f19209d9cb9050785afa46fbe51aec8660268b8e1f67f9aa3a"
 
 [[tasks]]
 name = "kubeply/recover-nightly-report-cronjob"

--- a/datasets/kubernetes-core/place-inference-canary-on-gpu-node/instruction.md
+++ b/datasets/kubernetes-core/place-inference-canary-on-gpu-node/instruction.md
@@ -7,12 +7,11 @@ A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
 The inference canary in the `vision-platform` namespace has not come online
-after a placement change. The existing CPU-only services in that namespace are
-serving normally.
+after a placement change. Other services in that namespace are serving normally.
 
 Repair the live cluster so the existing inference canary runs on the intended
-accelerator capacity, while the CPU-only services continue to run outside that
-capacity.
+specialized capacity while the unrelated services continue to run where they
+belong.
 
 Constraints:
 
@@ -20,10 +19,10 @@ Constraints:
 - Keep using the existing workloads and Services.
 - Preserve workload identities, selectors, pod labels, images, container ports,
   replica counts, and resource requests.
-- Keep the inference canary constrained to the simulated accelerator capacity.
-- Do not move CPU-only workloads onto accelerator capacity.
+- Keep the inference canary constrained to the intended specialized capacity.
+- Do not move unrelated workloads onto specialized capacity.
 - Do not delete and recreate workloads, add replacement workloads, add
-  standalone Pods, or change node labels or taints.
+  standalone Pods, or change node configuration.
 
-Success means the existing canary rolls out on the intended node class without
-replacement resources and without disturbing the healthy CPU-only apps.
+Success means the existing canary rolls out on the intended capacity without
+replacement resources and without disturbing healthy unrelated apps.

--- a/datasets/kubernetes-core/prepare-node-drain-with-pdb/instruction.md
+++ b/datasets/kubernetes-core/prepare-node-drain-with-pdb/instruction.md
@@ -13,16 +13,15 @@ availability guarantees and leaving the other namespace workloads alone.
 
 Constraints:
 
-- Use `kubectl` to inspect node placement, workload state, and eviction
-  readiness before changing anything.
-- Keep the existing namespace, workloads, Services, node configuration, and
+- Use `kubectl` to inspect the live cluster before changing anything.
+- Keep the existing namespace, application resources, node configuration, and
   availability protections in place.
 - Preserve resource identities, selectors, pod labels, container images, ports,
   and Service contracts.
 - Do not remove availability protections or reduce availability guarantees to
   zero.
-- Do not delete or recreate workloads, Services, budgets, nodes, or the
-  namespace.
+- Do not delete or recreate workloads, Services, availability resources, nodes,
+  or the namespace.
 - Do not create replacement workloads, alternate Services, standalone Pods,
   jobs, or drain-bypass resources.
 - Do not broaden RBAC, restart the cluster, or edit files outside `/app` unless

--- a/datasets/kubernetes-core/prepare-node-drain-with-pdb/instruction.md
+++ b/datasets/kubernetes-core/prepare-node-drain-with-pdb/instruction.md
@@ -13,13 +13,14 @@ availability guarantees and leaving the other namespace workloads alone.
 
 Constraints:
 
-- Use `kubectl` to inspect node placement, workload state, and disruption
-  status before changing anything.
-- Keep the existing namespace, workloads, Services, node labels, and disruption
-  budgets in place.
+- Use `kubectl` to inspect node placement, workload state, and eviction
+  readiness before changing anything.
+- Keep the existing namespace, workloads, Services, node configuration, and
+  availability protections in place.
 - Preserve resource identities, selectors, pod labels, container images, ports,
   and Service contracts.
-- Do not delete disruption budgets or reduce availability guarantees to zero.
+- Do not remove availability protections or reduce availability guarantees to
+  zero.
 - Do not delete or recreate workloads, Services, budgets, nodes, or the
   namespace.
 - Do not create replacement workloads, alternate Services, standalone Pods,
@@ -27,5 +28,5 @@ Constraints:
 - Do not broaden RBAC, restart the cluster, or edit files outside `/app` unless
   needed for temporary notes.
 
-Success means the existing affected application can tolerate one normal pod
-eviction for the maintenance workflow and still return to full readiness.
+Success means the existing affected application can tolerate one normal
+maintenance-window eviction and still return to full readiness.

--- a/datasets/kubernetes-core/recover-api-rollout-after-config-change/instruction.md
+++ b/datasets/kubernetes-core/recover-api-rollout-after-config-change/instruction.md
@@ -6,24 +6,23 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-The orders API had a configuration change and its rollout is not completing.
-Some services in the namespace are healthy, so do not assume the whole
-namespace is broken.
+The orders API had a recent release and the new version is not taking traffic.
+Some services in the namespace are healthy, so do not assume the whole namespace
+is broken.
 
-Use `kubectl` to inspect the `orders-platform` namespace and restore the orders
-API rollout while keeping the existing service contract intact.
+Use `kubectl` to inspect the `orders-platform` namespace and restore the
+existing orders API while keeping its service contract intact.
 
 Constraints:
 
 - Use `kubectl` to inspect the live resources before changing anything.
-- Preserve the existing Deployments, Services, ConfigMaps, selectors, images,
-  ports, and replica counts unless live evidence points to one targeted field
-  that needs repair.
-- Do not delete and recreate Deployments, Services, ConfigMaps, or the
-  namespace.
+- Preserve the existing application resources, selectors, images, ports, and
+  replica counts unless live evidence points to one targeted field that needs
+  repair.
+- Do not delete and recreate application resources or the namespace.
 - Do not create replacement workloads or bypass resources.
 - Do not change the healthy admin or docs services.
 - Do not patch status or write verifier artifacts directly.
 
-Success means the existing orders API rollout completes and the Service has
-ready endpoints while the unrelated workloads remain healthy.
+Success means the existing orders API serves traffic from the intended release
+while the unrelated workloads remain healthy.

--- a/datasets/kubernetes-core/repair-restricted-multi-container-pod/instruction.md
+++ b/datasets/kubernetes-core/repair-restricted-multi-container-pod/instruction.md
@@ -2,6 +2,12 @@
 
 You are working in `/app`.
 
-The Kubernetes cluster is already running and `kubectl` is configured. In the `policy-lab` namespace, one multi-container app is not running under the existing restricted policy while other workloads are healthy.
+The Kubernetes cluster is already running and `kubectl` is configured. In the
+`policy-lab` namespace, one multi-container app is not running under the
+namespace's existing admission requirements while other workloads are healthy.
 
-Repair the existing workload so all of its containers run and become Ready under the current namespace policy. Preserve the namespace policy, existing workload identities, Services, and unrelated workloads. Do not delete the namespace, loosen policy labels, use privileged or host-level shortcuts, replace the workload, or reset the cluster.
+Repair the existing workload so all of its containers run and become Ready
+without changing the namespace's enforcement posture. Preserve namespace
+settings, existing workload identities, Services, and unrelated workloads. Do
+not delete the namespace, loosen policy labels, use privileged or host-level
+shortcuts, replace the workload, or reset the cluster.

--- a/datasets/kubernetes-core/repair-sidecar-generated-config/instruction.md
+++ b/datasets/kubernetes-core/repair-sidecar-generated-config/instruction.md
@@ -2,6 +2,12 @@
 
 You are working in `/app`.
 
-The Kubernetes cluster is already running and `kubectl` is configured. In the `edge-apps` namespace, one app that uses a sidecar never becomes healthy while nearby services are healthy.
+The Kubernetes cluster is already running and `kubectl` is configured. In the
+`edge-apps` namespace, one app no longer becomes healthy after a runtime
+configuration change while nearby services are healthy.
 
-Repair the existing live resources so the app becomes Ready with both containers still running. Preserve the Deployment identity, Service, generated-config pattern, and unrelated apps. Do not replace the app with a simpler workload, remove the sidecar, create one-off shortcuts, weaken RBAC, or reset the cluster.
+Repair the existing live resources so the app becomes Ready with its current
+multi-container design intact. Preserve the Deployment identity, Service,
+runtime configuration flow, and unrelated apps. Do not replace the app with a
+simpler workload, remove containers from the pod, create one-off shortcuts,
+weaken RBAC, or reset the cluster.

--- a/datasets/kubernetes-core/restore-grafana-logs-datasource/instruction.md
+++ b/datasets/kubernetes-core/restore-grafana-logs-datasource/instruction.md
@@ -2,6 +2,12 @@
 
 You are working in `/app`.
 
-The Kubernetes cluster is already running and `kubectl` is configured. In the `product-observability` namespace, Grafana loads but the log panels are empty.
+The Kubernetes cluster is already running and `kubectl` is configured. In the
+`product-observability` namespace, the observability UI loads, but recent log
+views are empty after a configuration change.
 
-Repair the existing live resources so Grafana uses the in-cluster logging backend and the log panels recover. Preserve existing workloads, services, service accounts, and unrelated applications. Do not delete the namespace, replace workloads, bypass the datasource through an external endpoint, weaken RBAC, or reset the cluster.
+Repair the existing live resources so the log views recover through the
+intended in-cluster path. Preserve existing workloads, services, service
+accounts, and unrelated applications. Do not delete the namespace, replace
+workloads, bypass the cluster path through an external endpoint, weaken RBAC, or
+reset the cluster.

--- a/datasets/kubernetes-core/restore-metrics-controller-after-values-change/instruction.md
+++ b/datasets/kubernetes-core/restore-metrics-controller-after-values-change/instruction.md
@@ -6,19 +6,19 @@ cluster.
 A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
-Clients that depend on a metrics-like controller are reporting that the
-controller-backed dependency is unavailable after a chart values change. Repair
-the live cluster so the existing controller Service has ready endpoints again.
+Clients that depend on the platform metrics component are reporting failures
+after a chart values change. Repair the live cluster so the existing component
+serves those clients again without disturbing unrelated workloads.
 
 Constraints:
 
 - Use `kubectl` to inspect the live cluster before changing anything.
-- Keep using the existing controller Deployment and Service.
-- Preserve resource identities, chart-style labels, pod labels, image, Service
-  port, target port, container port, and replica count.
-- Do not delete and recreate the Service or Deployment.
-- Do not reinstall the controller, add replacement workloads, add standalone
-  Pods, or create replacement Services.
+- Keep using the existing component resources.
+- Preserve resource identities, chart-style ownership, workload identity,
+  routing contracts, image, ports, and replica count.
+- Do not delete and recreate existing resources.
+- Do not reinstall the component, add replacement workloads, add standalone
+  Pods, or create bypass resources.
 
-Success means the existing Service has ready endpoints for the existing
-controller pods without adding a replacement controller or Service.
+Success means the existing metrics dependency is available to its clients again
+without replacement resources or broad chart rewrites.


### PR DESCRIPTION
Tighten the instructions for eight Kubernetes medium tasks that were leaking too much of the diagnostic path.

The updated prompts keep the same task goals, constraints, and verifiers, but remove direct references such as Service endpoints, datasource wiring, generated-config patterns, disruption budgets, and node-label/taint hints. This should make the tasks sit better in the medium range by requiring agents to inspect live cluster evidence before choosing the relevant Kubernetes resource relationship to repair.

The Kubernetes dataset manifest was refreshed with new digests for the affected tasks after the instruction changes.

Validated with:

- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/terraform-core`
- `git diff --check`