### PR TITLE
feat(kubernetes): Add healthy sidecar gateway

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -161,7 +161,7 @@ digest = "sha256:b634d592c737e34208669b1c86ad53c5205560d936eb3cacc26b5d61835d27c
 
 [[tasks]]
 name = "kubeply/repair-sidecar-generated-config"
-digest = "sha256:426f288ea38ec9d7a8b22c14db28579020dd704a873dca610693cbf26d511a09"
+digest = "sha256:655bcd0fdab0d814956ad0bb6655640e3355858d0b132cbe375add2bd92338cc"
 
 [[tasks]]
 name = "kubeply/repair-restricted-multi-container-pod"

--- a/datasets/kubernetes-core/repair-sidecar-generated-config/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/repair-sidecar-generated-config/environment/scripts/bootstrap-cluster
@@ -8,7 +8,7 @@ prepare-kubeconfig
 
 kubectl apply -f /bootstrap/sidecar.yaml
 
-for deployment in docs status-api cache-warmer; do
+for deployment in docs status-api audit-gateway cache-warmer; do
   kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=180s
 done
 
@@ -33,6 +33,9 @@ for item in \
   "docs_service_uid:service:docs" \
   "status_deployment_uid:deployment:status-api" \
   "status_service_uid:service:status-api" \
+  "audit_deployment_uid:deployment:audit-gateway" \
+  "audit_service_uid:service:audit-gateway" \
+  "audit_template_uid:configmap:audit-template" \
   "cache_deployment_uid:deployment:cache-warmer"; do
   IFS=: read -r key kind name <<< "$item"
   uid="$(kubectl -n "$namespace" get "$kind" "$name" -o jsonpath='{.metadata.uid}')"

--- a/datasets/kubernetes-core/repair-sidecar-generated-config/environment/workspace/bootstrap/sidecar.yaml
+++ b/datasets/kubernetes-core/repair-sidecar-generated-config/environment/workspace/bootstrap/sidecar.yaml
@@ -66,6 +66,9 @@ data:
   docs_service_uid: ""
   status_deployment_uid: ""
   status_service_uid: ""
+  audit_deployment_uid: ""
+  audit_service_uid: ""
+  audit_template_uid: ""
   cache_deployment_uid: ""
 ---
 apiVersion: v1
@@ -75,6 +78,14 @@ metadata:
   namespace: edge-apps
 data:
   backend: profile-api
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: audit-template
+  namespace: edge-apps
+data:
+  backend: audit-api
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -159,6 +170,94 @@ metadata:
 spec:
   selector:
     app: profile-gateway
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit-gateway
+  namespace: edge-apps
+  labels:
+    app: audit-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: audit-gateway
+  template:
+    metadata:
+      labels:
+        app: audit-gateway
+    spec:
+      containers:
+        - name: app
+          image: busybox:1.36.1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /www
+              httpd -p 8080 -h /www &
+              while true; do
+                if [ -f /config/app.conf ] && grep -q "backend=audit-api" /config/app.conf; then
+                  echo "ok" > /www/ready
+                  echo "audit gateway loaded generated config from /config/app.conf"
+                else
+                  rm -f /www/ready
+                  echo "audit gateway waiting for generated config at /config/app.conf" >&2
+                fi
+                sleep 3
+              done
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: generated-config
+              mountPath: /config
+          readinessProbe:
+            exec:
+              command: ["test", "-f", "/www/ready"]
+            periodSeconds: 2
+        - name: config-writer
+          image: busybox:1.36.1
+          env:
+            - name: CONFIG_OUTPUT
+              value: /generated/app.conf
+            - name: BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: audit-template
+                  key: backend
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              while true; do
+                mkdir -p "$(dirname "${CONFIG_OUTPUT}")"
+                printf 'backend=%s\n' "${BACKEND}" > "${CONFIG_OUTPUT}"
+                echo "wrote generated config to ${CONFIG_OUTPUT}"
+                sleep 3
+              done
+          volumeMounts:
+            - name: generated-config
+              mountPath: /generated
+      volumes:
+        - name: generated-config
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: audit-gateway
+  namespace: edge-apps
+spec:
+  selector:
+    app: audit-gateway
   ports:
     - name: http
       port: 8080

--- a/datasets/kubernetes-core/repair-sidecar-generated-config/tests/test_sidecar_generated_config.sh
+++ b/datasets/kubernetes-core/repair-sidecar-generated-config/tests/test_sidecar_generated_config.sh
@@ -46,29 +46,34 @@ expect_uid deployment docs docs_deployment_uid
 expect_uid service docs docs_service_uid
 expect_uid deployment status-api status_deployment_uid
 expect_uid service status-api status_service_uid
+expect_uid deployment audit-gateway audit_deployment_uid
+expect_uid service audit-gateway audit_service_uid
+expect_uid configmap audit-template audit_template_uid
 expect_uid deployment cache-warmer cache_deployment_uid
 
 deployments="$(kubectl -n "$namespace" get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
-[[ "$deployments" == "cache-warmer docs profile-gateway status-api " ]] || fail "unexpected Deployments: $deployments"
+[[ "$deployments" == "audit-gateway cache-warmer docs profile-gateway status-api " ]] || fail "unexpected Deployments: $deployments"
 
 services="$(kubectl -n "$namespace" get services -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
-[[ "$services" == "docs profile-gateway status-api " ]] || fail "unexpected Services: $services"
+[[ "$services" == "audit-gateway docs profile-gateway status-api " ]] || fail "unexpected Services: $services"
 
 configmaps="$(kubectl -n "$namespace" get configmaps -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
-[[ "$configmaps" == "infra-bench-baseline kube-root-ca.crt profile-template " ]] || fail "unexpected ConfigMaps: $configmaps"
+[[ "$configmaps" == "audit-template infra-bench-baseline kube-root-ca.crt profile-template " ]] || fail "unexpected ConfigMaps: $configmaps"
 
 for resource in statefulsets daemonsets jobs cronjobs; do
   count="$(kubectl -n "$namespace" get "$resource" -o name | wc -l | tr -d ' ')"
   [[ "$count" == "0" ]] || fail "unexpected $resource were created"
 done
 
-for deployment in profile-gateway docs status-api cache-warmer; do
+for deployment in profile-gateway docs status-api audit-gateway cache-warmer; do
   kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=180s \
     || fail "deployment/$deployment did not complete rollout"
 done
 
-endpoint_ips="$(kubectl -n "$namespace" get endpoints profile-gateway -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
-[[ -n "$endpoint_ips" ]] || fail "profile-gateway Service has no endpoints"
+for service in profile-gateway docs status-api audit-gateway; do
+  endpoint_ips="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
+  [[ -n "$endpoint_ips" ]] || fail "$service Service has no endpoints"
+done
 
 container_names="$(kubectl -n "$namespace" get deployment profile-gateway -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}' | sort | tr '\n' ' ')"
 [[ "$container_names" == "app config-writer " ]] || fail "profile-gateway must keep app and sidecar containers"
@@ -92,6 +97,15 @@ template_backend="$(kubectl -n "$namespace" get configmap profile-template -o js
 
 cache_containers="$(kubectl -n "$namespace" get deployment cache-warmer -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}' | sort | tr '\n' ' ')"
 [[ "$cache_containers" == "cache-config-writer worker " ]] || fail "unrelated sidecar workload changed"
+
+audit_containers="$(kubectl -n "$namespace" get deployment audit-gateway -o jsonpath='{range .spec.template.spec.containers[*]}{.name}{"\n"}{end}' | sort | tr '\n' ' ')"
+audit_output_path="$(kubectl -n "$namespace" get deployment audit-gateway -o jsonpath='{.spec.template.spec.containers[1].env[?(@.name=="CONFIG_OUTPUT")].value}')"
+audit_backend_ref="$(kubectl -n "$namespace" get deployment audit-gateway -o jsonpath='{.spec.template.spec.containers[1].env[?(@.name=="BACKEND")].valueFrom.configMapKeyRef.name}')"
+audit_template_backend="$(kubectl -n "$namespace" get configmap audit-template -o jsonpath='{.data.backend}')"
+[[ "$audit_containers" == "app config-writer " ]] || fail "healthy sidecar gateway changed containers"
+[[ "$audit_output_path" == "/generated/app.conf" ]] || fail "healthy sidecar gateway output path changed"
+[[ "$audit_backend_ref" == "audit-template" && "$audit_template_backend" == "audit-api" ]] \
+  || fail "healthy sidecar gateway template changed"
 
 for _ in $(seq 1 90); do
   if kubectl -n "$namespace" logs deployment/profile-gateway -c app --tail=80 2>/dev/null \


### PR DESCRIPTION
Make `repair-sidecar-generated-config` more realistic while preserving its bounded single-workload repair.

This adds a healthy `audit-gateway` workload and Service that use the same app-plus-config-writer sidecar pattern correctly. Agents now need to isolate `profile-gateway` instead of applying generic sidecar changes across the namespace.

The verifier preserves the new gateway, its template ConfigMap, and its Service while still checking that `profile-gateway` consumes the generated config from the intended shared path. The Kubernetes dataset digest was refreshed for the changed task.

Validated with:

- `bash -n` on the changed task scripts
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/repair-sidecar-generated-config -a oracle`
- `git diff --check`