### PR TITLE
feat(kubernetes): Add peer API rollout context

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -109,7 +109,7 @@ digest = "sha256:23035e2bf05bd4c283e44544b368d4771b1bb0cf77bc7b3fc8e4f2786dad9b0
 
 [[tasks]]
 name = "kubeply/recover-api-rollout-after-config-change"
-digest = "sha256:b3bc5e35224fb920c8399b310194e44136298e559c01b557b6fb9300ee238e64"
+digest = "sha256:277074c8abeeb7ad119faf54e5d9e66d0eaeb76506da7f7559c9d35187837baa"
 
 [[tasks]]
 name = "kubeply/schedule-reporting-api-on-labeled-node"

--- a/datasets/kubernetes-core/recover-api-rollout-after-config-change/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/recover-api-rollout-after-config-change/environment/scripts/bootstrap-cluster
@@ -8,7 +8,7 @@ prepare-kubeconfig
 
 kubectl apply -f /bootstrap/app.yaml
 
-for deployment in orders-api admin docs; do
+for deployment in orders-api billing-api admin docs; do
   kubectl -n "$namespace" rollout status "deployment/${deployment}" --timeout=180s
 done
 
@@ -17,6 +17,9 @@ orders_api_deployment_uid="$(
 )"
 admin_deployment_uid="$(
   kubectl -n "$namespace" get deployment admin -o jsonpath='{.metadata.uid}'
+)"
+billing_api_deployment_uid="$(
+  kubectl -n "$namespace" get deployment billing-api -o jsonpath='{.metadata.uid}'
 )"
 docs_deployment_uid="$(
   kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}'
@@ -27,11 +30,17 @@ orders_api_service_uid="$(
 admin_service_uid="$(
   kubectl -n "$namespace" get service admin -o jsonpath='{.metadata.uid}'
 )"
+billing_api_service_uid="$(
+  kubectl -n "$namespace" get service billing-api -o jsonpath='{.metadata.uid}'
+)"
 docs_service_uid="$(
   kubectl -n "$namespace" get service docs -o jsonpath='{.metadata.uid}'
 )"
 orders_api_config_uid="$(
   kubectl -n "$namespace" get configmap orders-api-config -o jsonpath='{.metadata.uid}'
+)"
+billing_api_config_uid="$(
+  kubectl -n "$namespace" get configmap billing-api-config -o jsonpath='{.metadata.uid}'
 )"
 
 kubectl -n "$namespace" patch configmap infra-bench-baseline \
@@ -40,12 +49,15 @@ kubectl -n "$namespace" patch configmap infra-bench-baseline \
 {
   "data": {
     "orders_api_deployment_uid": "${orders_api_deployment_uid}",
+    "billing_api_deployment_uid": "${billing_api_deployment_uid}",
     "admin_deployment_uid": "${admin_deployment_uid}",
     "docs_deployment_uid": "${docs_deployment_uid}",
     "orders_api_service_uid": "${orders_api_service_uid}",
+    "billing_api_service_uid": "${billing_api_service_uid}",
     "admin_service_uid": "${admin_service_uid}",
     "docs_service_uid": "${docs_service_uid}",
-    "orders_api_config_uid": "${orders_api_config_uid}"
+    "orders_api_config_uid": "${orders_api_config_uid}",
+    "billing_api_config_uid": "${billing_api_config_uid}"
   }
 }
 PATCH

--- a/datasets/kubernetes-core/recover-api-rollout-after-config-change/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/recover-api-rollout-after-config-change/environment/workspace/bootstrap/app.yaml
@@ -12,6 +12,14 @@ data:
   health_path: healthz
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: billing-api-config
+  namespace: orders-platform
+data:
+  health_path: readyz
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infra-bench-agent
@@ -134,6 +142,68 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: billing-api
+  namespace: orders-platform
+  labels:
+    app: billing-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: billing-api
+  template:
+    metadata:
+      labels:
+        app: billing-api
+      annotations:
+        config-revision: readyz
+    spec:
+      containers:
+        - name: billing-api
+          image: busybox:1.36.1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              path="${HEALTH_PATH#/}"
+              mkdir -p /www
+              printf 'billing-ok\n' > "/www/${path}"
+              printf 'billing health endpoint is /%s\n' "${path}"
+              exec httpd -f -p 8080 -h /www
+          env:
+            - name: HEALTH_PATH
+              valueFrom:
+                configMapKeyRef:
+                  name: billing-api-config
+                  key: health_path
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: http
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: billing-api
+  namespace: orders-platform
+spec:
+  selector:
+    app: billing-api
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: admin
   namespace: orders-platform
   labels:
@@ -246,9 +316,12 @@ metadata:
   namespace: orders-platform
 data:
   orders_api_deployment_uid: ""
+  billing_api_deployment_uid: ""
   admin_deployment_uid: ""
   docs_deployment_uid: ""
   orders_api_service_uid: ""
+  billing_api_service_uid: ""
   admin_service_uid: ""
   docs_service_uid: ""
   orders_api_config_uid: ""
+  billing_api_config_uid: ""

--- a/datasets/kubernetes-core/recover-api-rollout-after-config-change/tests/test_rollout_config.sh
+++ b/datasets/kubernetes-core/recover-api-rollout-after-config-change/tests/test_rollout_config.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 prepare-kubeconfig
 
 namespace="orders-platform"
-deployments=(admin docs orders-api)
-services=(admin docs orders-api)
+deployments=(admin billing-api docs orders-api)
+services=(admin billing-api docs orders-api)
 
 dump_debug() {
   echo "--- deployments ---"
@@ -61,23 +61,32 @@ assert_uid_preserved() {
 }
 
 assert_uid_preserved deployment orders-api orders_api_deployment_uid
+assert_uid_preserved deployment billing-api billing_api_deployment_uid
 assert_uid_preserved deployment admin admin_deployment_uid
 assert_uid_preserved deployment docs docs_deployment_uid
 assert_uid_preserved service orders-api orders_api_service_uid
+assert_uid_preserved service billing-api billing_api_service_uid
 assert_uid_preserved service admin admin_service_uid
 assert_uid_preserved service docs docs_service_uid
 assert_uid_preserved configmap orders-api-config orders_api_config_uid
+assert_uid_preserved configmap billing-api-config billing_api_config_uid
 
 deployment_names="$(kubectl -n "$namespace" get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 service_names="$(kubectl -n "$namespace" get services -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
+configmap_names="$(kubectl -n "$namespace" get configmaps -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 
-if [[ "$deployment_names" != $'admin\ndocs\norders-api' ]]; then
+if [[ "$deployment_names" != $'admin\nbilling-api\ndocs\norders-api' ]]; then
   echo "Unexpected Deployment set in ${namespace}: ${deployment_names}" >&2
   exit 1
 fi
 
-if [[ "$service_names" != $'admin\ndocs\norders-api' ]]; then
+if [[ "$service_names" != $'admin\nbilling-api\ndocs\norders-api' ]]; then
   echo "Unexpected Service set in ${namespace}: ${service_names}" >&2
+  exit 1
+fi
+
+if [[ "$configmap_names" != $'billing-api-config\ninfra-bench-baseline\nkube-root-ca.crt\norders-api-config' ]]; then
+  echo "Unexpected ConfigMap set in ${namespace}: ${configmap_names}" >&2
   exit 1
 fi
 
@@ -122,6 +131,7 @@ done
 orders_replicas="$(kubectl -n "$namespace" get deployment orders-api -o jsonpath='{.spec.replicas}')"
 orders_ready="$(kubectl -n "$namespace" get deployment orders-api -o jsonpath='{.status.readyReplicas}')"
 admin_replicas="$(kubectl -n "$namespace" get deployment admin -o jsonpath='{.spec.replicas}')"
+billing_replicas="$(kubectl -n "$namespace" get deployment billing-api -o jsonpath='{.spec.replicas}')"
 docs_replicas="$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.spec.replicas}')"
 readiness_path="$(kubectl -n "$namespace" get deployment orders-api -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}')"
 readiness_port="$(kubectl -n "$namespace" get deployment orders-api -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.port}')"
@@ -134,8 +144,8 @@ if [[ "$orders_replicas" != "2" || "$orders_ready" != "2" ]]; then
   exit 1
 fi
 
-if [[ "$admin_replicas" != "1" || "$docs_replicas" != "1" ]]; then
-  echo "Noisy workload replica counts changed: admin=${admin_replicas} docs=${docs_replicas}" >&2
+if [[ "$admin_replicas" != "1" || "$billing_replicas" != "1" || "$docs_replicas" != "1" ]]; then
+  echo "Noisy workload replica counts changed: admin=${admin_replicas} billing=${billing_replicas} docs=${docs_replicas}" >&2
   exit 1
 fi
 
@@ -151,6 +161,15 @@ fi
 
 if [[ "$health_path" != "readyz" || "$config_revision" != "readyz" ]]; then
   echo "Config-driven rollout state changed unexpectedly: health_path=${health_path} revision=${config_revision}" >&2
+  exit 1
+fi
+
+billing_readiness_path="$(kubectl -n "$namespace" get deployment billing-api -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}')"
+billing_health_path="$(kubectl -n "$namespace" get configmap billing-api-config -o jsonpath='{.data.health_path}')"
+billing_config_revision="$(kubectl -n "$namespace" get deployment billing-api -o jsonpath='{.spec.template.metadata.annotations.config-revision}')"
+
+if [[ "$billing_readiness_path" != "/readyz" || "$billing_health_path" != "readyz" || "$billing_config_revision" != "readyz" ]]; then
+  echo "Healthy peer API config-driven readiness changed: readiness=${billing_readiness_path} health=${billing_health_path} revision=${billing_config_revision}" >&2
   exit 1
 fi
 
@@ -176,15 +195,15 @@ for _ in $(seq 1 60); do
   pod_count="$(kubectl -n "$namespace" get pods -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -c . || true)"
   ready_pods="$(kubectl -n "$namespace" get pods -o jsonpath='{range .items[*]}{range .status.conditions[?(@.type=="Ready")]}{.status}{"\n"}{end}{end}' | grep -c '^True$' || true)"
 
-  if [[ "$pod_count" == "4" && "$ready_pods" == "4" ]]; then
+  if [[ "$pod_count" == "5" && "$ready_pods" == "5" ]]; then
     break
   fi
 
   sleep 1
 done
 
-if [[ "$pod_count" != "4" || "$ready_pods" != "4" ]]; then
-  echo "Expected four ready pods after rollout, got pods=${pod_count} ready=${ready_pods}" >&2
+if [[ "$pod_count" != "5" || "$ready_pods" != "5" ]]; then
+  echo "Expected five ready pods after rollout, got pods=${pod_count} ready=${ready_pods}" >&2
   dump_debug
   exit 1
 fi
@@ -205,6 +224,13 @@ orders_log="$(kubectl -n "$namespace" logs -l app=orders-api --all-containers=tr
 if ! grep -q 'orders health endpoint is /readyz' <<< "$orders_log"; then
   echo "orders-api logs do not show the config-driven /readyz endpoint" >&2
   echo "$orders_log" >&2
+  exit 1
+fi
+
+billing_log="$(kubectl -n "$namespace" logs -l app=billing-api --all-containers=true --tail=80)"
+if ! grep -q 'billing health endpoint is /readyz' <<< "$billing_log"; then
+  echo "billing-api logs do not show the preserved /readyz endpoint" >&2
+  echo "$billing_log" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Make `recover-api-rollout-after-config-change` more realistic while keeping the intended repair bounded to `orders-api`.

This adds a healthy `billing-api` peer that uses the same config-driven readiness pattern correctly. Agents now have a realistic comparison point in the namespace and must avoid changing the healthy peer while repairing the stuck orders rollout.

The verifier preserves the peer Deployment, Service, ConfigMap, and endpoint behavior, and the Kubernetes dataset digest was refreshed for the changed task.

Validated with:

- `bash -n` on the changed task scripts
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/recover-api-rollout-after-config-change -a oracle`
- `git diff --check`