### PR TITLE
feat(kubernetes): Add extra drain-safe workload

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -129,7 +129,7 @@ digest = "sha256:0cd32f7297433cf24031308ffbfc78ed7e5779326269019b7dc4a332a8d5f12
 
 [[tasks]]
 name = "kubeply/prepare-node-drain-with-pdb"
-digest = "sha256:78f15054154313a997b47750f9606f628ce8be5930b472b3769e010feda1988c"
+digest = "sha256:69764053c8cb4b6f170260a77c33dd4ccc90d2d1d471a2581547c273a566e3fe"
 
 [[tasks]]
 name = "kubeply/repair-worker-hpa-scaling-inputs"

--- a/datasets/kubernetes-core/prepare-node-drain-with-pdb/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/prepare-node-drain-with-pdb/environment/scripts/bootstrap-cluster
@@ -34,7 +34,7 @@ kubectl label node "$general_node" infra-bench/node-pool=general infra-bench/dra
 
 kubectl apply -f /bootstrap/drain.yaml
 
-for deployment in orders-api docs background-worker; do
+for deployment in orders-api docs background-worker reporting-api; do
   if ! kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=180s; then
     kubectl -n "$namespace" get all,pdb -o wide >&2 || true
     kubectl -n "$namespace" describe deployment "$deployment" >&2 || true
@@ -52,16 +52,17 @@ for _ in $(seq 1 90); do
   )"
   orders_pdb_allowed="$(kubectl -n "$namespace" get pdb orders-api -o jsonpath='{.status.disruptionsAllowed}' 2>/dev/null || true)"
   worker_pdb_allowed="$(kubectl -n "$namespace" get pdb background-worker -o jsonpath='{.status.disruptionsAllowed}' 2>/dev/null || true)"
+  reporting_pdb_allowed="$(kubectl -n "$namespace" get pdb reporting-api -o jsonpath='{.status.disruptionsAllowed}' 2>/dev/null || true)"
 
-  if [[ "$orders_on_maintenance" == "2" && "$orders_pdb_allowed" == "0" && "$worker_pdb_allowed" -ge 1 ]]; then
+  if [[ "$orders_on_maintenance" == "2" && "$orders_pdb_allowed" == "0" && "$worker_pdb_allowed" -ge 1 && "$reporting_pdb_allowed" -ge 1 ]]; then
     break
   fi
 
   sleep 1
 done
 
-if [[ "$orders_on_maintenance" != "2" || "$orders_pdb_allowed" != "0" || "$worker_pdb_allowed" -lt 1 ]]; then
-  echo "expected orders-api pods pinned to maintenance node with PDB blocking one eviction, and worker PDB already allowing one" >&2
+if [[ "$orders_on_maintenance" != "2" || "$orders_pdb_allowed" != "0" || "$worker_pdb_allowed" -lt 1 || "$reporting_pdb_allowed" -lt 1 ]]; then
+  echo "expected orders-api pods pinned to maintenance node with PDB blocking one eviction, and other PDBs already allowing one" >&2
   kubectl get nodes --show-labels >&2 || true
   kubectl -n "$namespace" get pods -o wide >&2 || true
   kubectl -n "$namespace" get pdb -o wide >&2 || true
@@ -72,15 +73,18 @@ fi
 orders_deployment_uid="$(kubectl -n "$namespace" get deployment orders-api -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}')"
 worker_deployment_uid="$(kubectl -n "$namespace" get deployment background-worker -o jsonpath='{.metadata.uid}')"
+reporting_deployment_uid="$(kubectl -n "$namespace" get deployment reporting-api -o jsonpath='{.metadata.uid}')"
 orders_service_uid="$(kubectl -n "$namespace" get service orders-api -o jsonpath='{.metadata.uid}')"
 docs_service_uid="$(kubectl -n "$namespace" get service docs -o jsonpath='{.metadata.uid}')"
 worker_service_uid="$(kubectl -n "$namespace" get service background-worker -o jsonpath='{.metadata.uid}')"
+reporting_service_uid="$(kubectl -n "$namespace" get service reporting-api -o jsonpath='{.metadata.uid}')"
 orders_pdb_uid="$(kubectl -n "$namespace" get pdb orders-api -o jsonpath='{.metadata.uid}')"
 worker_pdb_uid="$(kubectl -n "$namespace" get pdb background-worker -o jsonpath='{.metadata.uid}')"
+reporting_pdb_uid="$(kubectl -n "$namespace" get pdb reporting-api -o jsonpath='{.metadata.uid}')"
 
 kubectl -n "$namespace" patch configmap infra-bench-baseline \
   --type merge \
-  --patch "{\"data\":{\"orders_deployment_uid\":\"${orders_deployment_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"worker_deployment_uid\":\"${worker_deployment_uid}\",\"orders_service_uid\":\"${orders_service_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"worker_service_uid\":\"${worker_service_uid}\",\"orders_pdb_uid\":\"${orders_pdb_uid}\",\"worker_pdb_uid\":\"${worker_pdb_uid}\",\"maintenance_node_name\":\"${maintenance_node}\",\"general_node_name\":\"${general_node}\"}}"
+  --patch "{\"data\":{\"orders_deployment_uid\":\"${orders_deployment_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"worker_deployment_uid\":\"${worker_deployment_uid}\",\"reporting_deployment_uid\":\"${reporting_deployment_uid}\",\"orders_service_uid\":\"${orders_service_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"worker_service_uid\":\"${worker_service_uid}\",\"reporting_service_uid\":\"${reporting_service_uid}\",\"orders_pdb_uid\":\"${orders_pdb_uid}\",\"worker_pdb_uid\":\"${worker_pdb_uid}\",\"reporting_pdb_uid\":\"${reporting_pdb_uid}\",\"maintenance_node_name\":\"${maintenance_node}\",\"general_node_name\":\"${general_node}\"}}"
 
 for _ in $(seq 1 60); do
   token_data="$(kubectl -n "$namespace" get secret "$agent_secret" -o jsonpath='{.data.token}' 2>/dev/null || true)"

--- a/datasets/kubernetes-core/prepare-node-drain-with-pdb/environment/workspace/bootstrap/drain.yaml
+++ b/datasets/kubernetes-core/prepare-node-drain-with-pdb/environment/workspace/bootstrap/drain.yaml
@@ -94,11 +94,14 @@ data:
   orders_deployment_uid: ""
   docs_deployment_uid: ""
   worker_deployment_uid: ""
+  reporting_deployment_uid: ""
   orders_service_uid: ""
   docs_service_uid: ""
   worker_service_uid: ""
+  reporting_service_uid: ""
   orders_pdb_uid: ""
   worker_pdb_uid: ""
+  reporting_pdb_uid: ""
   maintenance_node_name: ""
   general_node_name: ""
 ---
@@ -288,3 +291,69 @@ spec:
   selector:
     matchLabels:
       app: background-worker
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reporting-api
+  namespace: platform-team
+  labels:
+    app: reporting-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: reporting-api
+  template:
+    metadata:
+      labels:
+        app: reporting-api
+    spec:
+      containers:
+        - name: reporting-api
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /www
+              echo "reporting ready" > /www/ready
+              exec httpd -f -p 8080 -h /www
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: reporting-api
+  namespace: platform-team
+  labels:
+    app: reporting-api
+spec:
+  selector:
+    app: reporting-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: reporting-api
+  namespace: platform-team
+  labels:
+    app: reporting-api
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: reporting-api

--- a/datasets/kubernetes-core/prepare-node-drain-with-pdb/tests/test_drain_pdb.sh
+++ b/datasets/kubernetes-core/prepare-node-drain-with-pdb/tests/test_drain_pdb.sh
@@ -102,11 +102,14 @@ general_node="$(baseline general_node_name)"
 expect_uid deployment orders-api orders_deployment_uid
 expect_uid deployment docs docs_deployment_uid
 expect_uid deployment background-worker worker_deployment_uid
+expect_uid deployment reporting-api reporting_deployment_uid
 expect_uid service orders-api orders_service_uid
 expect_uid service docs docs_service_uid
 expect_uid service background-worker worker_service_uid
+expect_uid service reporting-api reporting_service_uid
 expect_uid pdb orders-api orders_pdb_uid
 expect_uid pdb background-worker worker_pdb_uid
+expect_uid pdb reporting-api reporting_pdb_uid
 
 maintenance_label="$(kubectl get node "$maintenance_node" -o jsonpath='{.metadata.labels.infra-bench/node-pool}')"
 general_label="$(kubectl get node "$general_node" -o jsonpath='{.metadata.labels.infra-bench/node-pool}')"
@@ -120,9 +123,9 @@ service_names="$(kubectl -n "$namespace" get services -o jsonpath='{range .items
 pdb_names="$(kubectl -n "$namespace" get pdb -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 configmap_names="$(kubectl -n "$namespace" get configmaps -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 
-[[ "$deployment_names" == $'background-worker\ndocs\norders-api' ]] || fail "unexpected deployments: $deployment_names"
-[[ "$service_names" == $'background-worker\ndocs\norders-api' ]] || fail "unexpected services: $service_names"
-[[ "$pdb_names" == $'background-worker\norders-api' ]] || fail "unexpected PDBs: $pdb_names"
+[[ "$deployment_names" == $'background-worker\ndocs\norders-api\nreporting-api' ]] || fail "unexpected deployments: $deployment_names"
+[[ "$service_names" == $'background-worker\ndocs\norders-api\nreporting-api' ]] || fail "unexpected services: $service_names"
+[[ "$pdb_names" == $'background-worker\norders-api\nreporting-api' ]] || fail "unexpected PDBs: $pdb_names"
 [[ "$configmap_names" == $'infra-bench-baseline\nkube-root-ca.crt' ]] || fail "unexpected configmaps: $configmap_names"
 
 unexpected_workloads="$(
@@ -138,9 +141,11 @@ unexpected_workloads="$(
 expect_deployment_common orders-api 3
 expect_deployment_common docs 1
 expect_deployment_common background-worker 2
+expect_deployment_common reporting-api 3
 expect_service orders-api
 expect_service docs
 expect_service background-worker
+expect_service reporting-api
 
 orders_selector_count="$(kubectl -n "$namespace" get deployment orders-api -o go-template='{{if .spec.template.spec.nodeSelector}}{{len .spec.template.spec.nodeSelector}}{{else}}0{{end}}')"
 orders_pdb_min="$(kubectl -n "$namespace" get pdb orders-api -o jsonpath='{.spec.minAvailable}')"
@@ -149,11 +154,15 @@ orders_pdb_selector="$(kubectl -n "$namespace" get pdb orders-api -o jsonpath='{
 orders_allowed="$(kubectl -n "$namespace" get pdb orders-api -o jsonpath='{.status.disruptionsAllowed}')"
 worker_pdb_max="$(kubectl -n "$namespace" get pdb background-worker -o jsonpath='{.spec.maxUnavailable}')"
 worker_pdb_selector="$(kubectl -n "$namespace" get pdb background-worker -o jsonpath='{.spec.selector.matchLabels.app}')"
+reporting_pdb_max="$(kubectl -n "$namespace" get pdb reporting-api -o jsonpath='{.spec.maxUnavailable}')"
+reporting_pdb_selector="$(kubectl -n "$namespace" get pdb reporting-api -o jsonpath='{.spec.selector.matchLabels.app}')"
+reporting_allowed="$(kubectl -n "$namespace" get pdb reporting-api -o jsonpath='{.status.disruptionsAllowed}')"
 
 [[ "$orders_selector_count" == "0" ]] || fail "orders-api still has maintenance-only nodeSelector"
 [[ "$orders_pdb_min" == "2" && -z "$orders_pdb_max" && "$orders_pdb_selector" == "orders-api" ]] || fail "orders-api PDB was weakened or retargeted"
 [[ "$orders_allowed" -ge 1 ]] || fail "orders-api PDB still does not allow one disruption"
 [[ "$worker_pdb_max" == "1" && "$worker_pdb_selector" == "background-worker" ]] || fail "background-worker PDB changed"
+[[ "$reporting_pdb_max" == "1" && "$reporting_pdb_selector" == "reporting-api" && "$reporting_allowed" -ge 1 ]] || fail "reporting-api PDB changed"
 
 general_orders="$(
   kubectl -n "$namespace" get pods -l app=orders-api \
@@ -162,7 +171,7 @@ general_orders="$(
 )"
 [[ "$general_orders" -ge 1 ]] || fail "orders-api did not schedule any pod outside the maintenance node"
 
-for service in orders-api docs background-worker; do
+for service in orders-api docs background-worker reporting-api; do
   endpoints="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
   [[ -n "$endpoints" ]] || fail "service/$service has no ready endpoints"
 done


### PR DESCRIPTION
Make `prepare-node-drain-with-pdb` more realistic while keeping the intended repair focused on `orders-api`.

This adds a healthy `reporting-api` service with its own meaningful PodDisruptionBudget that is already safe for one disruption. The task now has multiple availability protections in the namespace, so agents must identify the maintenance-blocking workload without weakening unrelated PDBs.

The verifier preserves the new workload, Service, and PDB, and checks that it remains disruption-safe while `orders-api` is repaired. The Kubernetes dataset digest was refreshed for the changed task.

Validated with:

- `bash -n` on the changed task scripts
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/prepare-node-drain-with-pdb -a oracle`
- `git diff --check`