### PR TITLE
feat(kubernetes): Add metrics dashboard dependency

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -125,7 +125,7 @@ digest = "sha256:cd780ecabe049ad97e65dbd4ae86434cca355f7c0756866d41bafda4017bebf
 
 [[tasks]]
 name = "kubeply/restore-metrics-controller-after-values-change"
-digest = "sha256:3da4c78a3fad5187727ada76dd6732b71f91711b4f42905b5b918fd116325045"
+digest = "sha256:0930afec3df98a71740ce9715fa37f4bae2e436fe06d5f3f1c990a480f527ff8"
 
 [[tasks]]
 name = "kubeply/prepare-node-drain-with-pdb"

--- a/datasets/kubernetes-core/restore-metrics-controller-after-values-change/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/restore-metrics-controller-after-values-change/environment/scripts/bootstrap-cluster
@@ -38,6 +38,21 @@ if [[ -n "$endpoint_ips" ]]; then
 fi
 
 for _ in $(seq 1 60); do
+  dashboard_ready="$(kubectl -n "$namespace" get deployment metrics-dashboard -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  if [[ "${dashboard_ready:-0}" == "0" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${dashboard_ready:-0}" != "0" ]]; then
+  echo "expected metrics-dashboard to start unready while metrics-adapter Service has no endpoints" >&2
+  kubectl -n "$namespace" get deployment metrics-dashboard -o yaml >&2 || true
+  kubectl -n "$namespace" logs deployment/metrics-dashboard --tail=80 >&2 || true
+  exit 1
+fi
+
+for _ in $(seq 1 60); do
   telemetry_endpoint_ips="$(kubectl -n "$namespace" get endpoints "$telemetry_service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
   telemetry_endpoint_port="$(kubectl -n "$namespace" get endpoints "$telemetry_service" -o jsonpath='{.subsets[0].ports[0].port}' 2>/dev/null || true)"
 
@@ -62,13 +77,15 @@ if [[ -z "$baseline_deployment_uid" || -z "$baseline_service_uid" ]]; then
   deployment_uid="$(kubectl -n "$namespace" get deployment "$deployment" -o jsonpath='{.metadata.uid}')"
   service_uid="$(kubectl -n "$namespace" get service "$service" -o jsonpath='{.metadata.uid}')"
   values_uid="$(kubectl -n "$namespace" get configmap metrics-adapter-values -o jsonpath='{.metadata.uid}')"
+  dashboard_deployment_uid="$(kubectl -n "$namespace" get deployment metrics-dashboard -o jsonpath='{.metadata.uid}')"
+  dashboard_service_uid="$(kubectl -n "$namespace" get service metrics-dashboard -o jsonpath='{.metadata.uid}')"
   telemetry_deployment_uid="$(kubectl -n "$namespace" get deployment "$telemetry_deployment" -o jsonpath='{.metadata.uid}')"
   telemetry_service_uid="$(kubectl -n "$namespace" get service "$telemetry_service" -o jsonpath='{.metadata.uid}')"
   telemetry_values_uid="$(kubectl -n "$namespace" get configmap telemetry-proxy-values -o jsonpath='{.metadata.uid}')"
 
   kubectl -n "$namespace" patch configmap infra-bench-baseline \
     --type merge \
-    --patch "{\"data\":{\"deployment_uid\":\"${deployment_uid}\",\"service_uid\":\"${service_uid}\",\"values_uid\":\"${values_uid}\",\"telemetry_deployment_uid\":\"${telemetry_deployment_uid}\",\"telemetry_service_uid\":\"${telemetry_service_uid}\",\"telemetry_values_uid\":\"${telemetry_values_uid}\"}}"
+    --patch "{\"data\":{\"deployment_uid\":\"${deployment_uid}\",\"service_uid\":\"${service_uid}\",\"values_uid\":\"${values_uid}\",\"dashboard_deployment_uid\":\"${dashboard_deployment_uid}\",\"dashboard_service_uid\":\"${dashboard_service_uid}\",\"telemetry_deployment_uid\":\"${telemetry_deployment_uid}\",\"telemetry_service_uid\":\"${telemetry_service_uid}\",\"telemetry_values_uid\":\"${telemetry_values_uid}\"}}"
 fi
 
 for _ in $(seq 1 60); do

--- a/datasets/kubernetes-core/restore-metrics-controller-after-values-change/environment/workspace/bootstrap/controller.yaml
+++ b/datasets/kubernetes-core/restore-metrics-controller-after-values-change/environment/workspace/bootstrap/controller.yaml
@@ -238,6 +238,81 @@ data:
   deployment_uid: ""
   service_uid: ""
   values_uid: ""
+  dashboard_deployment_uid: ""
+  dashboard_service_uid: ""
   telemetry_deployment_uid: ""
   telemetry_service_uid: ""
   telemetry_values_uid: ""
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-dashboard
+  namespace: metrics-team
+  labels:
+    app.kubernetes.io/name: metrics-dashboard
+    app.kubernetes.io/component: client
+    app.kubernetes.io/instance: platform-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: metrics-dashboard
+      app.kubernetes.io/component: client
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: metrics-dashboard
+        app.kubernetes.io/component: client
+        app.kubernetes.io/instance: platform-metrics
+    spec:
+      containers:
+        - name: metrics-dashboard
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: METRICS_URL
+              value: http://metrics-adapter.metrics-team.svc.cluster.local:443/ready
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /www
+              httpd -p 8080 -h /www &
+              while true; do
+                if wget -qO- -T 3 "$METRICS_URL" | grep -q "metrics adapter ready"; then
+                  echo "ready" > /www/ready
+                  echo "metrics dashboard reached metrics-adapter"
+                else
+                  rm -f /www/ready
+                  echo "metrics dashboard cannot reach metrics-adapter" >&2
+                fi
+                sleep 3
+              done
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics-dashboard
+  namespace: metrics-team
+  labels:
+    app.kubernetes.io/name: metrics-dashboard
+    app.kubernetes.io/component: client
+    app.kubernetes.io/instance: platform-metrics
+spec:
+  selector:
+    app.kubernetes.io/name: metrics-dashboard
+    app.kubernetes.io/component: client
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/datasets/kubernetes-core/restore-metrics-controller-after-values-change/tests/test_controller_service.sh
+++ b/datasets/kubernetes-core/restore-metrics-controller-after-values-change/tests/test_controller_service.sh
@@ -10,6 +10,8 @@ values_configmap="metrics-adapter-values"
 telemetry_deployment="telemetry-proxy"
 telemetry_service="telemetry-proxy"
 telemetry_values_configmap="telemetry-proxy-values"
+dashboard_deployment="metrics-dashboard"
+dashboard_service="metrics-dashboard"
 
 dump_debug() {
   echo "--- namespace resources ---"
@@ -20,13 +22,15 @@ dump_debug() {
   kubectl -n "$namespace" get endpoints "$service" -o yaml || true
   echo "--- deployment yaml ---"
   kubectl -n "$namespace" get deployment "$deployment" -o yaml || true
+  echo "--- dashboard logs ---"
+  kubectl -n "$namespace" logs deployment/"$dashboard_deployment" --tail=120 || true
   echo "--- pod describe ---"
   kubectl -n "$namespace" describe pods || true
   echo "--- recent events ---"
   kubectl -n "$namespace" get events --sort-by=.lastTimestamp || true
 }
 
-for rollout_deployment in "$deployment" "$telemetry_deployment"; do
+for rollout_deployment in "$deployment" "$telemetry_deployment" "$dashboard_deployment"; do
   if kubectl -n "$namespace" rollout status deployment/"$rollout_deployment" --timeout=180s; then
     continue
   fi
@@ -40,16 +44,22 @@ values_uid="$(kubectl -n "$namespace" get configmap "$values_configmap" -o jsonp
 telemetry_deployment_uid="$(kubectl -n "$namespace" get deployment "$telemetry_deployment" -o jsonpath='{.metadata.uid}')"
 telemetry_service_uid="$(kubectl -n "$namespace" get service "$telemetry_service" -o jsonpath='{.metadata.uid}')"
 telemetry_values_uid="$(kubectl -n "$namespace" get configmap "$telemetry_values_configmap" -o jsonpath='{.metadata.uid}')"
+dashboard_deployment_uid="$(kubectl -n "$namespace" get deployment "$dashboard_deployment" -o jsonpath='{.metadata.uid}')"
+dashboard_service_uid="$(kubectl -n "$namespace" get service "$dashboard_service" -o jsonpath='{.metadata.uid}')"
 baseline_deployment_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.deployment_uid}')"
 baseline_service_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.service_uid}')"
 baseline_values_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.values_uid}')"
 baseline_telemetry_deployment_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.telemetry_deployment_uid}')"
 baseline_telemetry_service_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.telemetry_service_uid}')"
 baseline_telemetry_values_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.telemetry_values_uid}')"
+baseline_dashboard_deployment_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.dashboard_deployment_uid}')"
+baseline_dashboard_service_uid="$(kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath='{.data.dashboard_service_uid}')"
 
 if [[ -z "$baseline_deployment_uid" \
   || -z "$baseline_service_uid" \
   || -z "$baseline_values_uid" \
+  || -z "$baseline_dashboard_deployment_uid" \
+  || -z "$baseline_dashboard_service_uid" \
   || -z "$baseline_telemetry_deployment_uid" \
   || -z "$baseline_telemetry_service_uid" \
   || -z "$baseline_telemetry_values_uid" ]]; then
@@ -61,6 +71,8 @@ fi
 if [[ "$deployment_uid" != "$baseline_deployment_uid" \
   || "$service_uid" != "$baseline_service_uid" \
   || "$values_uid" != "$baseline_values_uid" \
+  || "$dashboard_deployment_uid" != "$baseline_dashboard_deployment_uid" \
+  || "$dashboard_service_uid" != "$baseline_dashboard_service_uid" \
   || "$telemetry_deployment_uid" != "$baseline_telemetry_deployment_uid" \
   || "$telemetry_service_uid" != "$baseline_telemetry_service_uid" \
   || "$telemetry_values_uid" != "$baseline_telemetry_values_uid" ]]; then
@@ -68,6 +80,8 @@ if [[ "$deployment_uid" != "$baseline_deployment_uid" \
   echo "deployment expected=${baseline_deployment_uid} got=${deployment_uid}" >&2
   echo "service expected=${baseline_service_uid} got=${service_uid}" >&2
   echo "values expected=${baseline_values_uid} got=${values_uid}" >&2
+  echo "dashboard deployment expected=${baseline_dashboard_deployment_uid} got=${dashboard_deployment_uid}" >&2
+  echo "dashboard service expected=${baseline_dashboard_service_uid} got=${dashboard_service_uid}" >&2
   echo "telemetry deployment expected=${baseline_telemetry_deployment_uid} got=${telemetry_deployment_uid}" >&2
   echo "telemetry service expected=${baseline_telemetry_service_uid} got=${telemetry_service_uid}" >&2
   echo "telemetry values expected=${baseline_telemetry_values_uid} got=${telemetry_values_uid}" >&2
@@ -78,7 +92,7 @@ deployment_names="$(kubectl -n "$namespace" get deployments -o jsonpath='{range 
 service_names="$(kubectl -n "$namespace" get services -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 configmap_names="$(kubectl -n "$namespace" get configmaps -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 
-if [[ "$deployment_names" != $'metrics-adapter\ntelemetry-proxy' || "$service_names" != $'metrics-adapter\ntelemetry-proxy' ]]; then
+if [[ "$deployment_names" != $'metrics-adapter\nmetrics-dashboard\ntelemetry-proxy' || "$service_names" != $'metrics-adapter\nmetrics-dashboard\ntelemetry-proxy' ]]; then
   echo "Unexpected Deployment or Service set: deployments=${deployment_names} services=${service_names}" >&2
   exit 1
 fi
@@ -158,6 +172,14 @@ telemetry_replicas="$(kubectl -n "$namespace" get deployment "$telemetry_deploym
 telemetry_ready_replicas="$(kubectl -n "$namespace" get deployment "$telemetry_deployment" -o jsonpath='{.status.readyReplicas}')"
 telemetry_service_port="$(kubectl -n "$namespace" get service "$telemetry_service" -o jsonpath='{.spec.ports[0].port}')"
 telemetry_target_port="$(kubectl -n "$namespace" get service "$telemetry_service" -o jsonpath='{.spec.ports[0].targetPort}')"
+dashboard_selector_name="$(kubectl -n "$namespace" get service "$dashboard_service" -o jsonpath='{.spec.selector.app\.kubernetes\.io/name}')"
+dashboard_selector_component="$(kubectl -n "$namespace" get service "$dashboard_service" -o jsonpath='{.spec.selector.app\.kubernetes\.io/component}')"
+dashboard_image="$(kubectl -n "$namespace" get deployment "$dashboard_deployment" -o jsonpath='{.spec.template.spec.containers[0].image}')"
+dashboard_replicas="$(kubectl -n "$namespace" get deployment "$dashboard_deployment" -o jsonpath='{.spec.replicas}')"
+dashboard_ready_replicas="$(kubectl -n "$namespace" get deployment "$dashboard_deployment" -o jsonpath='{.status.readyReplicas}')"
+dashboard_url="$(kubectl -n "$namespace" get deployment "$dashboard_deployment" -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="METRICS_URL")].value}')"
+dashboard_service_port="$(kubectl -n "$namespace" get service "$dashboard_service" -o jsonpath='{.spec.ports[0].port}')"
+dashboard_target_port="$(kubectl -n "$namespace" get service "$dashboard_service" -o jsonpath='{.spec.ports[0].targetPort}')"
 values_release="$(kubectl -n "$namespace" get configmap "$values_configmap" -o jsonpath='{.data.values\.yaml}' | grep -c 'release: platform-metrics' || true)"
 telemetry_values_release="$(kubectl -n "$namespace" get configmap "$telemetry_values_configmap" -o jsonpath='{.data.values\.yaml}' | grep -c 'release: telemetry-stack' || true)"
 
@@ -173,6 +195,26 @@ fi
 
 if [[ "$telemetry_service_port" != "443" || "$telemetry_target_port" != "https" ]]; then
   echo "Healthy telemetry Service port changed" >&2
+  exit 1
+fi
+
+if [[ "$dashboard_selector_name" != "$dashboard_deployment" || "$dashboard_selector_component" != "client" ]]; then
+  echo "Metrics dashboard Service selector changed" >&2
+  exit 1
+fi
+
+if [[ "$dashboard_image" != "busybox:1.36" || "$dashboard_replicas" != "1" || "$dashboard_ready_replicas" != "1" ]]; then
+  echo "Metrics dashboard did not recover; image=${dashboard_image} spec=${dashboard_replicas} ready=${dashboard_ready_replicas}" >&2
+  exit 1
+fi
+
+if [[ "$dashboard_url" != "http://metrics-adapter.metrics-team.svc.cluster.local:443/ready" ]]; then
+  echo "Metrics dashboard dependency URL changed: ${dashboard_url}" >&2
+  exit 1
+fi
+
+if [[ "$dashboard_service_port" != "80" || "$dashboard_target_port" != "http" ]]; then
+  echo "Metrics dashboard Service port changed" >&2
   exit 1
 fi
 
@@ -203,6 +245,13 @@ telemetry_endpoint_port="$(kubectl -n "$namespace" get endpoints "$telemetry_ser
 
 if [[ -z "$telemetry_endpoint_ips" || "$telemetry_endpoint_port" != "8443" ]]; then
   echo "Healthy telemetry Service lost its endpoints" >&2
+  dump_debug
+  exit 1
+fi
+
+dashboard_log="$(kubectl -n "$namespace" logs deployment/"$dashboard_deployment" --tail=120 2>/dev/null || true)"
+if ! grep -q "metrics dashboard reached metrics-adapter" <<< "$dashboard_log"; then
+  echo "Metrics dashboard did not reach the repaired metrics-adapter Service" >&2
   dump_debug
   exit 1
 fi


### PR DESCRIPTION
Strengthen `restore-metrics-controller-after-values-change` by adding a real dependent workload for the broken Service path.

The task was previously a clean but narrow Service selector repair. This adds a `metrics-dashboard` Deployment and Service that depend on `metrics-adapter.metrics-team.svc.cluster.local:443`. The dashboard remains unready while the adapter Service has no endpoints, so agents now see a client-facing symptom and logs in addition to the endpoint mismatch.

The intended fix remains targeted: repair the existing `metrics-adapter` Service selector while preserving chart-style labels, values ConfigMaps, the telemetry proxy distractor, and the new dashboard resources.

Validated with:

- `bash -n` on changed task scripts
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/terraform-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/restore-metrics-controller-after-values-change -a oracle`
- `git diff --check`
