### PR TITLE
feat(kubernetes): Add report publisher dependency

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -185,7 +185,7 @@ digest = "sha256:d0d528d26b8bbe03039ef842854b0b6ac20834d54c427b2365484436cdedd9b
 
 [[tasks]]
 name = "kubeply/repair-report-custom-resource-status"
-digest = "sha256:14e970e26f77541f7b81977ca91fa0d66b35c1d5c52205258ed03f22364cd99f"
+digest = "sha256:d7734749a8c6b65dc0885beb8ee23e739d2cbee068e87f1f78dd42c84bafb594"
 
 
 [[files]]

--- a/datasets/kubernetes-core/repair-report-custom-resource-status/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/repair-report-custom-resource-status/environment/scripts/bootstrap-cluster
@@ -8,6 +8,8 @@ target_report="sales-summary"
 healthy_report="traffic-summary"
 docs_deployment="docs"
 docs_service="docs"
+publisher_deployment="report-publisher"
+publisher_service="report-publisher"
 agent_secret="infra-bench-agent-token"
 
 prepare-kubeconfig
@@ -27,6 +29,21 @@ fi
 if ! kubectl -n "$namespace" rollout status deployment/"$docs_deployment" --timeout=240s; then
   kubectl -n "$namespace" get all -o wide >&2 || true
   kubectl -n "$namespace" describe deployment "$docs_deployment" >&2 || true
+  exit 1
+fi
+
+for _ in $(seq 1 60); do
+  publisher_ready="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
+  if [[ "${publisher_ready:-0}" == "0" ]]; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ "${publisher_ready:-0}" != "0" ]]; then
+  echo "expected report publisher to start unready before the sales report output exists" >&2
+  kubectl -n "$namespace" get deployment "$publisher_deployment" -o yaml >&2 || true
+  kubectl -n "$namespace" logs deployment/"$publisher_deployment" --tail=100 >&2 || true
   exit 1
 fi
 
@@ -84,13 +101,15 @@ crd_uid="$(kubectl get crd "$crd" -o jsonpath='{.metadata.uid}')"
 controller_uid="$(kubectl -n "$namespace" get deployment "$controller" -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment "$docs_deployment" -o jsonpath='{.metadata.uid}')"
 docs_service_uid="$(kubectl -n "$namespace" get service "$docs_service" -o jsonpath='{.metadata.uid}')"
+publisher_deployment_uid="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.metadata.uid}')"
+publisher_service_uid="$(kubectl -n "$namespace" get service "$publisher_service" -o jsonpath='{.metadata.uid}')"
 sales_config_uid="$(kubectl -n "$namespace" get configmap sales-report-template -o jsonpath='{.metadata.uid}')"
 traffic_config_uid="$(kubectl -n "$namespace" get configmap traffic-report-template -o jsonpath='{.metadata.uid}')"
 healthy_output_uid="$(kubectl -n "$namespace" get configmap report-output-traffic-summary -o jsonpath='{.metadata.uid}')"
 
 kubectl -n "$namespace" patch configmap infra-bench-baseline \
   --type merge \
-  --patch "{\"data\":{\"crd_uid\":\"${crd_uid}\",\"controller_uid\":\"${controller_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"healthy_report_uid\":\"${healthy_report_uid}\",\"healthy_output_uid\":\"${healthy_output_uid}\",\"sales_config_uid\":\"${sales_config_uid}\",\"target_report_uid\":\"${target_report_uid}\",\"traffic_config_uid\":\"${traffic_config_uid}\"}}"
+  --patch "{\"data\":{\"crd_uid\":\"${crd_uid}\",\"controller_uid\":\"${controller_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"publisher_deployment_uid\":\"${publisher_deployment_uid}\",\"publisher_service_uid\":\"${publisher_service_uid}\",\"healthy_report_uid\":\"${healthy_report_uid}\",\"healthy_output_uid\":\"${healthy_output_uid}\",\"sales_config_uid\":\"${sales_config_uid}\",\"target_report_uid\":\"${target_report_uid}\",\"traffic_config_uid\":\"${traffic_config_uid}\"}}"
 
 for _ in $(seq 1 60); do
   token_data="$(kubectl -n "$namespace" get secret "$agent_secret" -o jsonpath='{.data.token}' 2>/dev/null || true)"

--- a/datasets/kubernetes-core/repair-report-custom-resource-status/environment/workspace/bootstrap/operator.yaml
+++ b/datasets/kubernetes-core/repair-report-custom-resource-status/environment/workspace/bootstrap/operator.yaml
@@ -252,6 +252,77 @@ spec:
       port: 80
       targetPort: http
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-publisher
+  namespace: analytics-team
+  labels:
+    app: report-publisher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: report-publisher
+  template:
+    metadata:
+      labels:
+        app: report-publisher
+    spec:
+      containers:
+        - name: report-publisher
+          image: busybox:1.36.1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /www
+              httpd -p 8080 -h /www &
+              while true; do
+                source="$(cat /report/sourceConfig 2>/dev/null || true)"
+                template="$(cat /report/template 2>/dev/null || true)"
+                if [ "$source" = "sales-report-template" ] && [ "$template" = "sales-v1" ]; then
+                  echo "ready" > /www/ready
+                  echo "published sales report from ${source}"
+                else
+                  rm -f /www/ready
+                  echo "sales report output is not publishable yet" >&2
+                fi
+                sleep 3
+              done
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          volumeMounts:
+            - name: report-output
+              mountPath: /report
+              readOnly: true
+      volumes:
+        - name: report-output
+          configMap:
+            name: report-output-sales-summary
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: report-publisher
+  namespace: analytics-team
+  labels:
+    app: report-publisher
+spec:
+  selector:
+    app: report-publisher
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -316,6 +387,8 @@ data:
   controller_uid: ""
   docs_deployment_uid: ""
   docs_service_uid: ""
+  publisher_deployment_uid: ""
+  publisher_service_uid: ""
   healthy_report_uid: ""
   healthy_output_uid: ""
   sales_config_uid: ""

--- a/datasets/kubernetes-core/repair-report-custom-resource-status/tests/test_report_status.sh
+++ b/datasets/kubernetes-core/repair-report-custom-resource-status/tests/test_report_status.sh
@@ -8,6 +8,8 @@ crd="reports.platform.infra-bench.dev"
 controller="report-controller"
 docs_deployment="docs"
 docs_service="docs"
+publisher_deployment="report-publisher"
+publisher_service="report-publisher"
 target_report="sales-summary"
 healthy_report="traffic-summary"
 target_output="report-output-sales-summary"
@@ -30,6 +32,8 @@ dump_debug() {
   kubectl -n "$namespace" get deployment "$controller" -o yaml || true
   echo "--- controller logs ---"
   kubectl -n "$namespace" logs deployment/"$controller" --tail=150 || true
+  echo "--- publisher logs ---"
+  kubectl -n "$namespace" logs deployment/"$publisher_deployment" --tail=150 || true
   echo "--- recent events ---"
   kubectl -n "$namespace" get events --sort-by=.lastTimestamp || true
 }
@@ -44,6 +48,11 @@ if ! kubectl -n "$namespace" rollout status deployment/"$docs_deployment" --time
   exit 1
 fi
 
+if ! kubectl -n "$namespace" rollout status deployment/"$publisher_deployment" --timeout=180s; then
+  dump_debug
+  exit 1
+fi
+
 baseline_value() {
   kubectl -n "$namespace" get configmap infra-bench-baseline -o jsonpath="{.data.$1}"
 }
@@ -52,13 +61,15 @@ crd_uid="$(kubectl get crd "$crd" -o jsonpath='{.metadata.uid}')"
 controller_uid="$(kubectl -n "$namespace" get deployment "$controller" -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment "$docs_deployment" -o jsonpath='{.metadata.uid}')"
 docs_service_uid="$(kubectl -n "$namespace" get service "$docs_service" -o jsonpath='{.metadata.uid}')"
+publisher_deployment_uid="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.metadata.uid}')"
+publisher_service_uid="$(kubectl -n "$namespace" get service "$publisher_service" -o jsonpath='{.metadata.uid}')"
 target_report_uid="$(kubectl -n "$namespace" get report "$target_report" -o jsonpath='{.metadata.uid}')"
 healthy_report_uid="$(kubectl -n "$namespace" get report "$healthy_report" -o jsonpath='{.metadata.uid}')"
 sales_config_uid="$(kubectl -n "$namespace" get configmap sales-report-template -o jsonpath='{.metadata.uid}')"
 traffic_config_uid="$(kubectl -n "$namespace" get configmap traffic-report-template -o jsonpath='{.metadata.uid}')"
 healthy_output_uid="$(kubectl -n "$namespace" get configmap "$healthy_output" -o jsonpath='{.metadata.uid}')"
 
-for key in crd_uid controller_uid docs_deployment_uid docs_service_uid target_report_uid healthy_report_uid sales_config_uid traffic_config_uid healthy_output_uid; do
+for key in crd_uid controller_uid docs_deployment_uid docs_service_uid publisher_deployment_uid publisher_service_uid target_report_uid healthy_report_uid sales_config_uid traffic_config_uid healthy_output_uid; do
   if [[ -z "$(baseline_value "$key")" ]]; then
     echo "Baseline ConfigMap is missing $key" >&2
     kubectl -n "$namespace" get configmap infra-bench-baseline -o yaml || true
@@ -70,6 +81,8 @@ if [[ "$crd_uid" != "$(baseline_value crd_uid)" \
   || "$controller_uid" != "$(baseline_value controller_uid)" \
   || "$docs_deployment_uid" != "$(baseline_value docs_deployment_uid)" \
   || "$docs_service_uid" != "$(baseline_value docs_service_uid)" \
+  || "$publisher_deployment_uid" != "$(baseline_value publisher_deployment_uid)" \
+  || "$publisher_service_uid" != "$(baseline_value publisher_service_uid)" \
   || "$target_report_uid" != "$(baseline_value target_report_uid)" \
   || "$healthy_report_uid" != "$(baseline_value healthy_report_uid)" \
   || "$sales_config_uid" != "$(baseline_value sales_config_uid)" \
@@ -80,6 +93,8 @@ if [[ "$crd_uid" != "$(baseline_value crd_uid)" \
   echo "controller expected=$(baseline_value controller_uid) got=$controller_uid" >&2
   echo "docs deployment expected=$(baseline_value docs_deployment_uid) got=$docs_deployment_uid" >&2
   echo "docs service expected=$(baseline_value docs_service_uid) got=$docs_service_uid" >&2
+  echo "publisher deployment expected=$(baseline_value publisher_deployment_uid) got=$publisher_deployment_uid" >&2
+  echo "publisher service expected=$(baseline_value publisher_service_uid) got=$publisher_service_uid" >&2
   echo "target report expected=$(baseline_value target_report_uid) got=$target_report_uid" >&2
   echo "healthy report expected=$(baseline_value healthy_report_uid) got=$healthy_report_uid" >&2
   exit 1
@@ -95,7 +110,7 @@ if [[ "$report_names" != $'sales-summary\ntraffic-summary' ]]; then
   exit 1
 fi
 
-if [[ "$deployment_names" != $'docs\nreport-controller' || "$service_names" != "$docs_service" ]]; then
+if [[ "$deployment_names" != $'docs\nreport-controller\nreport-publisher' || "$service_names" != $'docs\nreport-publisher' ]]; then
   echo "Unexpected workload or Service set: deployments=${deployment_names} services=${service_names}" >&2
   exit 1
 fi
@@ -214,6 +229,13 @@ controller_ready_replicas="$(kubectl -n "$namespace" get deployment "$controller
 docs_image="$(kubectl -n "$namespace" get deployment "$docs_deployment" -o jsonpath='{.spec.template.spec.containers[0].image}')"
 docs_selector="$(kubectl -n "$namespace" get service "$docs_service" -o jsonpath='{.spec.selector.app}')"
 docs_endpoints="$(kubectl -n "$namespace" get endpoints "$docs_service" -o jsonpath='{.subsets[*].addresses[*].ip}')"
+publisher_image="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.spec.template.spec.containers[0].image}')"
+publisher_replicas="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.spec.replicas}')"
+publisher_ready_replicas="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.status.readyReplicas}')"
+publisher_selector="$(kubectl -n "$namespace" get service "$publisher_service" -o jsonpath='{.spec.selector.app}')"
+publisher_endpoints="$(kubectl -n "$namespace" get endpoints "$publisher_service" -o jsonpath='{.subsets[*].addresses[*].ip}')"
+publisher_volume="$(kubectl -n "$namespace" get deployment "$publisher_deployment" -o jsonpath='{.spec.template.spec.volumes[0].configMap.name}')"
+publisher_log="$(kubectl -n "$namespace" logs deployment/"$publisher_deployment" --tail=150 2>/dev/null || true)"
 crd_group="$(kubectl get crd "$crd" -o jsonpath='{.spec.group}')"
 crd_kind="$(kubectl get crd "$crd" -o jsonpath='{.spec.names.kind}')"
 crd_status_subresource="$(kubectl get crd "$crd" -o jsonpath='{.spec.versions[?(@.name=="v1alpha1")].subresources.status}')"
@@ -228,6 +250,22 @@ fi
 
 if [[ "$docs_image" != "nginx:1.27" || "$docs_selector" != "docs" || -z "$docs_endpoints" ]]; then
   echo "Docs service changed or lost endpoints; image=${docs_image} selector=${docs_selector} endpoints=${docs_endpoints}" >&2
+  exit 1
+fi
+
+if [[ "$publisher_image" != "busybox:1.36.1" \
+  || "$publisher_replicas" != "1" \
+  || "$publisher_ready_replicas" != "1" \
+  || "$publisher_selector" != "$publisher_deployment" \
+  || -z "$publisher_endpoints" \
+  || "$publisher_volume" != "$target_output" ]]; then
+  echo "Report publisher did not recover or its wiring changed; image=${publisher_image} spec=${publisher_replicas} ready=${publisher_ready_replicas} selector=${publisher_selector} endpoints=${publisher_endpoints} volume=${publisher_volume}" >&2
+  exit 1
+fi
+
+if ! grep -q "published sales report from sales-report-template" <<< "$publisher_log"; then
+  echo "Report publisher did not consume the generated sales report output" >&2
+  dump_debug
   exit 1
 fi
 


### PR DESCRIPTION
Strengthen `repair-report-custom-resource-status` by adding a downstream consumer of the controller-generated Report output.

The task still centers on repairing the existing `sales-summary` custom resource so the current controller can reconcile it, but now a `report-publisher` Deployment mounts `report-output-sales-summary` and remains unready until that generated ConfigMap exists with the expected sales template data. This gives the CR status issue a visible application-level symptom instead of only a status-field assertion.

The verifier preserves the controller, CRD, Reports, templates, docs service, and publisher resources. It also checks that the publisher consumes the generated output owned by the original Report.

Validated with:

- `bash -n` on changed task scripts
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/terraform-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/repair-report-custom-resource-status -a oracle`
- `git diff --check`
