### PR TITLE
feat(kubernetes): Add portal ingress synthetic monitor

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -149,7 +149,7 @@ digest = "sha256:16483bfceefab0046f52ad350bc69368ebdd85259f05c94652d9911fa8d7877
 
 [[tasks]]
 name = "kubeply/restore-portal-ingress-tls-route"
-digest = "sha256:04214ec40c38fbcc77c6fc0a29d45bff277ab3fc18b272fb0f342878c4ff81c5"
+digest = "sha256:19f9e6e54554752f864605340dfa7304dbb3628667431b04f71d72a839f191ca"
 
 [[tasks]]
 name = "kubeply/clear-upgrade-blocking-apis"

--- a/datasets/kubernetes-core/restore-portal-ingress-tls-route/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/restore-portal-ingress-tls-route/environment/scripts/bootstrap-cluster
@@ -46,7 +46,9 @@ for _ in $(seq 1 120); do
   if kubectl -n "$namespace" exec "$client_pod" -- wget -qO- -T 3 --header "Host: docs.example.test" http://traefik.kube-system.svc.cluster.local/ >/tmp/docs.out 2>/tmp/docs.err \
     && grep -q "docs route healthy" /tmp/docs.out \
     && kubectl -n "$namespace" exec "$client_pod" -- wget -qO- -T 3 http://internal-api:80/ >/tmp/internal-api.out 2>/tmp/internal-api.err \
-    && grep -q "internal api healthy" /tmp/internal-api.out; then
+    && grep -q "internal api healthy" /tmp/internal-api.out \
+    && kubectl -n "$namespace" logs deployment/ingress-client --tail=80 2>/tmp/client.err | grep -q "docs ingress check ok" \
+    && kubectl -n "$namespace" logs deployment/ingress-client --tail=80 2>/tmp/client.err | grep -q "internal service check ok"; then
     break
   fi
 
@@ -82,13 +84,14 @@ internal_service_uid="$(kubectl -n "$namespace" get service internal-api -o json
 portal_deployment_uid="$(kubectl -n "$namespace" get deployment portal -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}')"
 internal_deployment_uid="$(kubectl -n "$namespace" get deployment internal-api -o jsonpath='{.metadata.uid}')"
+client_deployment_uid="$(kubectl -n "$namespace" get deployment ingress-client -o jsonpath='{.metadata.uid}')"
 portal_secret_uid="$(kubectl -n "$namespace" get secret portal-tls -o jsonpath='{.metadata.uid}')"
 portal_old_secret_uid="$(kubectl -n "$namespace" get secret portal-old-tls -o jsonpath='{.metadata.uid}')"
 docs_secret_uid="$(kubectl -n "$namespace" get secret docs-tls -o jsonpath='{.metadata.uid}')"
 
 kubectl -n "$namespace" patch configmap infra-bench-baseline \
   --type merge \
-  --patch "{\"data\":{\"portal_ingress_uid\":\"${portal_ingress_uid}\",\"docs_ingress_uid\":\"${docs_ingress_uid}\",\"portal_service_uid\":\"${portal_service_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"internal_service_uid\":\"${internal_service_uid}\",\"portal_deployment_uid\":\"${portal_deployment_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"internal_deployment_uid\":\"${internal_deployment_uid}\",\"portal_secret_uid\":\"${portal_secret_uid}\",\"portal_old_secret_uid\":\"${portal_old_secret_uid}\",\"docs_secret_uid\":\"${docs_secret_uid}\"}}"
+  --patch "{\"data\":{\"portal_ingress_uid\":\"${portal_ingress_uid}\",\"docs_ingress_uid\":\"${docs_ingress_uid}\",\"portal_service_uid\":\"${portal_service_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"internal_service_uid\":\"${internal_service_uid}\",\"portal_deployment_uid\":\"${portal_deployment_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"internal_deployment_uid\":\"${internal_deployment_uid}\",\"client_deployment_uid\":\"${client_deployment_uid}\",\"portal_secret_uid\":\"${portal_secret_uid}\",\"portal_old_secret_uid\":\"${portal_old_secret_uid}\",\"docs_secret_uid\":\"${docs_secret_uid}\"}}"
 
 for _ in $(seq 1 60); do
   token_data="$(kubectl -n "$namespace" get secret "$agent_secret" -o jsonpath='{.data.token}' 2>/dev/null || true)"

--- a/datasets/kubernetes-core/restore-portal-ingress-tls-route/environment/workspace/bootstrap/ingress.yaml
+++ b/datasets/kubernetes-core/restore-portal-ingress-tls-route/environment/workspace/bootstrap/ingress.yaml
@@ -351,7 +351,28 @@ spec:
       containers:
         - name: ingress-client
           image: busybox:1.36
-          command: ["sh", "-c", "sleep 3600"]
+          command:
+            - sh
+            - -c
+            - |
+              while true; do
+                if wget -qO- -T 3 --header "Host: portal.example.test" http://traefik.kube-system.svc.cluster.local/ | grep -q "portal route restored"; then
+                  echo "portal ingress check ok"
+                else
+                  echo "portal ingress check failed" >&2
+                fi
+                if wget -qO- -T 3 --header "Host: docs.example.test" http://traefik.kube-system.svc.cluster.local/ | grep -q "docs route healthy"; then
+                  echo "docs ingress check ok"
+                else
+                  echo "docs ingress check failed" >&2
+                fi
+                if wget -qO- -T 3 http://internal-api:80/ | grep -q "internal api healthy"; then
+                  echo "internal service check ok"
+                else
+                  echo "internal service check failed" >&2
+                fi
+                sleep 5
+              done
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -367,6 +388,7 @@ data:
   portal_deployment_uid: ""
   docs_deployment_uid: ""
   internal_deployment_uid: ""
+  client_deployment_uid: ""
   portal_secret_uid: ""
   portal_old_secret_uid: ""
   docs_secret_uid: ""

--- a/datasets/kubernetes-core/restore-portal-ingress-tls-route/tests/test_portal_route.sh
+++ b/datasets/kubernetes-core/restore-portal-ingress-tls-route/tests/test_portal_route.sh
@@ -19,6 +19,8 @@ dump_debug() {
   kubectl -n "$namespace" get services -o yaml || true
   echo "--- deployments yaml ---"
   kubectl -n "$namespace" get deployments -o yaml || true
+  echo "--- ingress client logs ---"
+  kubectl -n "$namespace" logs deployment/"$client_deployment" --tail=160 || true
   echo "--- endpoints yaml ---"
   kubectl -n "$namespace" get endpoints -o yaml || true
   echo "--- pod describe ---"
@@ -152,6 +154,7 @@ check_uid service internal-api internal_service_uid
 check_uid deployment portal portal_deployment_uid
 check_uid deployment docs docs_deployment_uid
 check_uid deployment internal-api internal_deployment_uid
+check_uid deployment "$client_deployment" client_deployment_uid
 check_uid secret portal-tls portal_secret_uid
 check_uid secret portal-old-tls portal_old_secret_uid
 check_uid secret docs-tls docs_secret_uid
@@ -289,12 +292,16 @@ if [[ -z "$client_pod" || "$traefik_service" != "traefik" ]]; then
 fi
 
 for _ in $(seq 1 30); do
+  client_log="$(kubectl -n "$namespace" logs deployment/"$client_deployment" --tail=160 2>/tmp/client.err || true)"
   if kubectl -n "$namespace" exec "$client_pod" -- wget -qO- -T 3 --header "Host: portal.example.test" http://traefik.kube-system.svc.cluster.local/ >/tmp/portal.out 2>/tmp/portal.err \
     && grep -q "portal route restored" /tmp/portal.out \
     && kubectl -n "$namespace" exec "$client_pod" -- wget -qO- -T 3 --header "Host: docs.example.test" http://traefik.kube-system.svc.cluster.local/ >/tmp/docs.out 2>/tmp/docs.err \
     && grep -q "docs route healthy" /tmp/docs.out \
     && kubectl -n "$namespace" exec "$client_pod" -- wget -qO- -T 3 http://internal-api:80/ >/tmp/internal-api.out 2>/tmp/internal-api.err \
-    && grep -q "internal api healthy" /tmp/internal-api.out; then
+    && grep -q "internal api healthy" /tmp/internal-api.out \
+    && grep -q "portal ingress check ok" <<< "$client_log" \
+    && grep -q "docs ingress check ok" <<< "$client_log" \
+    && grep -q "internal service check ok" <<< "$client_log"; then
     echo "Portal route reaches the preserved backend, and existing namespace services still work"
     exit 0
   fi


### PR DESCRIPTION
Improve `restore-portal-ingress-tls-route` by turning the ingress client into an active synthetic monitor.

The task already checked the portal, docs, and internal API paths through verifier execs, but the in-cluster client was only a sleeping pod. This change makes `ingress-client` continuously probe the portal host through Traefik, the healthy docs host, and the internal API service. The verifier now requires that monitor to observe the repaired portal path while preserving the monitor Deployment identity.

The intended fix remains the existing targeted Ingress repair: restore the portal TLS Secret and backend Service port without replacing workloads, Services, Secrets, or unrelated routes.

Validated with:

- `bash -n` on changed task scripts
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/terraform-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/restore-portal-ingress-tls-route -a oracle`
- `git diff --check`
