### PR TITLE
feat(kubernetes): Add checkout order queue payload

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -173,7 +173,7 @@ digest = "sha256:0a6778afe4d65eeda407f008cd80e8be2fb07df8f346acac9055464111cbf27
 
 [[tasks]]
 name = "kubeply/reconnect-checkout-worker-queue"
-digest = "sha256:51daaf8a738933cc2c00e2f80c3744119cad80374942b3fe49b60ab600c56784"
+digest = "sha256:0b315dc0dee39ee268ab4e1bd33df566400abb2628fc75dae7ea560ba869f424"
 
 [[tasks]]
 name = "kubeply/restore-grafana-logs-datasource"

--- a/datasets/kubernetes-core/reconnect-checkout-worker-queue/environment/workspace/bootstrap/checkout.yaml
+++ b/datasets/kubernetes-core/reconnect-checkout-worker-queue/environment/workspace/bootstrap/checkout.yaml
@@ -118,7 +118,7 @@ spec:
             - -c
             - |
               mkdir -p /www
-              echo "checkout-queue-ok" > /www/process
+              echo "checkout-order-1842:pending" > /www/process
               httpd -f -p 5672 -h /www
           ports:
             - name: queue
@@ -169,8 +169,8 @@ spec:
             - |
               set -eu
               while true; do
-                if wget -qO- "${QUEUE_URL}" 2>/dev/null | grep -q "checkout-queue-ok"; then
-                  echo "processed checkout order through ${QUEUE_URL}"
+                if wget -qO- "${QUEUE_URL}" 2>/dev/null | grep -q "checkout-order-1842:pending"; then
+                  echo "processed checkout order checkout-order-1842 through ${QUEUE_URL}"
                 else
                   echo "checkout worker queue connection failed for ${QUEUE_URL}" >&2
                 fi
@@ -203,6 +203,7 @@ spec:
             - |
               mkdir -p /www
               echo "checkout-api-ok" > /www/ready
+              echo "checkout-order-1842 waiting-for-worker" > /www/orders
               httpd -f -p 8080 -h /www
           ports:
             - name: http

--- a/datasets/kubernetes-core/reconnect-checkout-worker-queue/solution/solve.sh
+++ b/datasets/kubernetes-core/reconnect-checkout-worker-queue/solution/solve.sh
@@ -11,7 +11,7 @@ kubectl -n "$namespace" patch deployment checkout-worker --type=json \
 kubectl -n "$namespace" rollout status deployment/checkout-worker --timeout=180s
 
 for _ in $(seq 1 60); do
-  if kubectl -n "$namespace" logs deployment/checkout-worker --tail=40 2>/dev/null | grep -q "processed checkout order"; then
+  if kubectl -n "$namespace" logs deployment/checkout-worker --tail=40 2>/dev/null | grep -q "processed checkout order checkout-order-1842"; then
     exit 0
   fi
   sleep 1

--- a/datasets/kubernetes-core/reconnect-checkout-worker-queue/tests/test_checkout_worker_queue.sh
+++ b/datasets/kubernetes-core/reconnect-checkout-worker-queue/tests/test_checkout_worker_queue.sh
@@ -113,6 +113,8 @@ inventory_worker_url="$(kubectl -n "$namespace" get deployment inventory-worker 
 checkout_worker_sa="$(kubectl -n "$namespace" get deployment checkout-worker -o jsonpath='{.spec.template.spec.serviceAccountName}')"
 checkout_worker_image="$(kubectl -n "$namespace" get deployment checkout-worker -o jsonpath='{.spec.template.spec.containers[0].image}')"
 inventory_worker_image="$(kubectl -n "$namespace" get deployment inventory-worker -o jsonpath='{.spec.template.spec.containers[0].image}')"
+checkout_queue_command="$(kubectl -n "$namespace" get deployment checkout-queue -o jsonpath='{.spec.template.spec.containers[0].command}')"
+checkout_api_command="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.spec.template.spec.containers[0].command}')"
 
 [[ "$checkout_queue_port" == "5673" && "$checkout_queue_target" == "queue" ]] \
   || fail "checkout queue Service port relationship changed"
@@ -124,6 +126,11 @@ inventory_worker_image="$(kubectl -n "$namespace" get deployment inventory-worke
 [[ "$checkout_worker_sa" == "checkout-runner" ]] || fail "checkout worker ServiceAccount changed"
 [[ "$checkout_worker_image" == "busybox:1.36.1" && "$inventory_worker_image" == "busybox:1.36.1" ]] \
   || fail "worker images changed"
+
+grep -q "checkout-order-1842:pending" <<< "$checkout_queue_command" \
+  || fail "checkout queue payload changed"
+grep -q "checkout-order-1842 waiting-for-worker" <<< "$checkout_api_command" \
+  || fail "checkout API order state changed"
 
 if grep -Eq 'https?://(localhost|127\.0\.0\.1|host\.docker\.internal|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|[^. ]+\.com)' <<< "$checkout_worker_url"; then
   fail "checkout worker uses an external or host-local queue endpoint"
@@ -139,14 +146,14 @@ done
 
 for _ in $(seq 1 90); do
   if kubectl -n "$namespace" logs deployment/checkout-worker --tail=80 2>/dev/null \
-    | grep -q "processed checkout order through http://checkout-queue.retail-stack.svc.cluster.local:5673/process"; then
+    | grep -q "processed checkout order checkout-order-1842 through http://checkout-queue.retail-stack.svc.cluster.local:5673/process"; then
     break
   fi
   sleep 1
 done
 
 if ! kubectl -n "$namespace" logs deployment/checkout-worker --tail=100 2>/dev/null \
-  | grep -q "processed checkout order through http://checkout-queue.retail-stack.svc.cluster.local:5673/process"; then
+  | grep -q "processed checkout order checkout-order-1842 through http://checkout-queue.retail-stack.svc.cluster.local:5673/process"; then
   fail "checkout worker did not process through the repaired queue path"
 fi
 


### PR DESCRIPTION
Strengthen the reconnect checkout worker queue medium task with a concrete checkout order payload instead of a generic queue health string.

The starting cluster now exposes checkout-order-1842 as pending on the checkout queue and shows the same order as waiting in the checkout API. The worker must process that specific order through the existing checkout-queue Service path after repairing its queue URL, which makes the scenario less synthetic while preserving the intended targeted fix.

The verifier keeps the existing resource identity and bypass checks, verifies the queue/API payload declarations through allowed Kubernetes reads, and requires worker logs proving the repaired Service path processed the concrete order.

Validation run:
- bash -n on the changed shell scripts
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core
- uvx --from harbor harbor run -p datasets/kubernetes-core/reconnect-checkout-worker-queue -a oracle, reward 1.0
- git diff --check