### PR TITLE
feat(kubernetes): Add worker recovery status service

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -121,7 +121,7 @@ digest = "sha256:23d08f4bae84323d6440087983475c28a90bb794151035f28249cd50d5c155b
 
 [[tasks]]
 name = "kubeply/restore-worker-config-access"
-digest = "sha256:cd780ecabe049ad97e65dbd4ae86434cca355f7c0756866d41bafda4017bebf2"
+digest = "sha256:61a55edf1e05c33031fa49cb49a36e05fe8b85ec5f77eadb6e16002aad1c4fd8"
 
 [[tasks]]
 name = "kubeply/restore-metrics-controller-after-values-change"

--- a/datasets/kubernetes-core/restore-worker-config-access/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/restore-worker-config-access/environment/scripts/bootstrap-cluster
@@ -8,7 +8,7 @@ prepare-kubeconfig
 
 kubectl apply -f /bootstrap/app.yaml
 
-for deployment in docs-api audit-api; do
+for deployment in docs-api audit-api status-api; do
   kubectl -n "$namespace" rollout status "deployment/${deployment}" --timeout=180s
 done
 
@@ -26,6 +26,9 @@ docs_deployment_uid="$(
 audit_deployment_uid="$(
   kubectl -n "$namespace" get deployment audit-api -o jsonpath='{.metadata.uid}'
 )"
+status_deployment_uid="$(
+  kubectl -n "$namespace" get deployment status-api -o jsonpath='{.metadata.uid}'
+)"
 worker_service_uid="$(
   kubectl -n "$namespace" get service fulfillment-worker -o jsonpath='{.metadata.uid}'
 )"
@@ -34,6 +37,9 @@ docs_service_uid="$(
 )"
 audit_service_uid="$(
   kubectl -n "$namespace" get service audit-api -o jsonpath='{.metadata.uid}'
+)"
+status_service_uid="$(
+  kubectl -n "$namespace" get service status-api -o jsonpath='{.metadata.uid}'
 )"
 worker_sa_uid="$(
   kubectl -n "$namespace" get serviceaccount fulfillment-worker -o jsonpath='{.metadata.uid}'
@@ -54,6 +60,14 @@ binding_uid="$(
   kubectl -n "$namespace" get rolebinding fulfillment-runtime-reader -o jsonpath='{.metadata.uid}'
 )"
 
+for _ in $(seq 1 60); do
+  if kubectl -n "$namespace" logs deployment/status-api --tail=20 2>/dev/null \
+    | grep -q 'fulfillment jobs stuck via http://fulfillment-worker.fulfillment-platform.svc.cluster.local/ready'; then
+    break
+  fi
+  sleep 1
+done
+
 kubectl -n "$namespace" patch configmap infra-bench-baseline \
   --type merge \
   --patch "$(cat <<PATCH
@@ -62,9 +76,11 @@ kubectl -n "$namespace" patch configmap infra-bench-baseline \
     "worker_deployment_uid": "${worker_deployment_uid}",
     "docs_deployment_uid": "${docs_deployment_uid}",
     "audit_deployment_uid": "${audit_deployment_uid}",
+    "status_deployment_uid": "${status_deployment_uid}",
     "worker_service_uid": "${worker_service_uid}",
     "docs_service_uid": "${docs_service_uid}",
     "audit_service_uid": "${audit_service_uid}",
+    "status_service_uid": "${status_service_uid}",
     "worker_sa_uid": "${worker_sa_uid}",
     "admin_sa_uid": "${admin_sa_uid}",
     "runtime_config_uid": "${runtime_config_uid}",

--- a/datasets/kubernetes-core/restore-worker-config-access/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/restore-worker-config-access/environment/workspace/bootstrap/app.yaml
@@ -87,9 +87,11 @@ data:
   worker_deployment_uid: ""
   docs_deployment_uid: ""
   audit_deployment_uid: ""
+  status_deployment_uid: ""
   worker_service_uid: ""
   docs_service_uid: ""
   audit_service_uid: ""
+  status_service_uid: ""
   worker_sa_uid: ""
   admin_sa_uid: ""
   runtime_config_uid: ""
@@ -323,6 +325,74 @@ metadata:
 spec:
   selector:
     app: audit-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: status-api
+  namespace: fulfillment-platform
+  labels:
+    app: status-api
+    component: status
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: status-api
+  template:
+    metadata:
+      labels:
+        app: status-api
+        component: status
+    spec:
+      containers:
+        - name: status
+          image: busybox:1.36.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              mkdir -p /www
+              echo "ok" > /www/ready
+              echo "jobs-stuck" > /www/status
+              httpd -f -p 8080 -h /www &
+              worker_url="http://fulfillment-worker.fulfillment-platform.svc.cluster.local/ready"
+              while true; do
+                if wget -qO- "$worker_url" 2>/dev/null | grep -q '^ok$'; then
+                  echo "jobs-processing" > /www/status
+                  echo "fulfillment jobs draining via ${worker_url}"
+                else
+                  echo "jobs-stuck" > /www/status
+                  echo "fulfillment jobs stuck via ${worker_url}" >&2
+                fi
+                sleep 4
+              done
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: status-api
+  namespace: fulfillment-platform
+  labels:
+    app: status-api
+spec:
+  selector:
+    app: status-api
   ports:
     - name: http
       port: 80

--- a/datasets/kubernetes-core/restore-worker-config-access/tests/test_worker_config_access.sh
+++ b/datasets/kubernetes-core/restore-worker-config-access/tests/test_worker_config_access.sh
@@ -56,9 +56,11 @@ expect_uid() {
 expect_uid deployment fulfillment-worker worker_deployment_uid
 expect_uid deployment docs-api docs_deployment_uid
 expect_uid deployment audit-api audit_deployment_uid
+expect_uid deployment status-api status_deployment_uid
 expect_uid service fulfillment-worker worker_service_uid
 expect_uid service docs-api docs_service_uid
 expect_uid service audit-api audit_service_uid
+expect_uid service status-api status_service_uid
 expect_uid serviceaccount fulfillment-worker worker_sa_uid
 expect_uid serviceaccount fulfillment-admin admin_sa_uid
 expect_uid configmap worker-runtime runtime_config_uid
@@ -67,10 +69,10 @@ expect_uid role fulfillment-runtime-reader role_uid
 expect_uid rolebinding fulfillment-runtime-reader binding_uid
 
 deployments="$(kubectl -n "$namespace" get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
-[[ "$deployments" == "audit-api docs-api fulfillment-worker " ]] || fail "unexpected Deployments: $deployments"
+[[ "$deployments" == "audit-api docs-api fulfillment-worker status-api " ]] || fail "unexpected Deployments: $deployments"
 
 services="$(kubectl -n "$namespace" get services -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
-[[ "$services" == "audit-api docs-api fulfillment-worker " ]] || fail "unexpected Services: $services"
+[[ "$services" == "audit-api docs-api fulfillment-worker status-api " ]] || fail "unexpected Services: $services"
 
 for resource in statefulsets daemonsets jobs cronjobs; do
   count="$(kubectl -n "$namespace" get "$resource" -o name | wc -l | tr -d ' ')"
@@ -114,24 +116,35 @@ role_ref_name="$(kubectl -n "$namespace" get rolebinding fulfillment-runtime-rea
   || fail "RoleBinding must reference the intended Role"
 
 
-for deployment in fulfillment-worker docs-api audit-api; do
+for deployment in fulfillment-worker docs-api audit-api status-api; do
   kubectl -n "$namespace" rollout status "deployment/${deployment}" --timeout=120s \
     || fail "deployment/${deployment} did not complete rollout"
 done
 
-for deployment in fulfillment-worker docs-api audit-api; do
+for deployment in fulfillment-worker docs-api audit-api status-api; do
   desired="$(kubectl -n "$namespace" get deployment "$deployment" -o jsonpath='{.spec.replicas}')"
   ready="$(kubectl -n "$namespace" get deployment "$deployment" -o jsonpath='{.status.readyReplicas}')"
   [[ "${ready:-0}" == "$desired" ]] || fail "$deployment has $ready/$desired ready replicas"
 done
 
-for service in fulfillment-worker docs-api audit-api; do
+for service in fulfillment-worker docs-api audit-api status-api; do
   endpoints="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}')"
   [[ -n "$endpoints" ]] || fail "service/$service has no ready endpoints"
 done
 
 if ! kubectl -n "$namespace" logs deployment/fulfillment-worker --tail=40 | grep -q 'loaded runtime profile'; then
   fail "worker logs do not show resumed processing"
+fi
+
+status_selector="$(kubectl -n "$namespace" get service status-api -o jsonpath='{.spec.selector.app}')"
+status_target_port="$(kubectl -n "$namespace" get service status-api -o jsonpath='{.spec.ports[0].targetPort}')"
+status_image="$(kubectl -n "$namespace" get deployment status-api -o jsonpath='{.spec.template.spec.containers[0].image}')"
+[[ "$status_selector" == "status-api" && "$status_target_port" == "http" && "$status_image" == "busybox:1.36.1" ]] \
+  || fail "status-api app or Service changed unexpectedly"
+
+if ! kubectl -n "$namespace" logs deployment/status-api --tail=60 2>/dev/null \
+  | grep -q 'fulfillment jobs draining via http://fulfillment-worker.fulfillment-platform.svc.cluster.local/ready'; then
+  fail "status-api logs do not show downstream recovery through the worker Service"
 fi
 
 echo "fulfillment worker recovered with minimal runtime ConfigMap access"


### PR DESCRIPTION
Strengthen the restore worker config access medium task with a downstream status service that reflects whether the fulfillment worker is actually processing again.

The task still requires the same least-privilege RBAC repair on the existing worker ServiceAccount and ConfigMap reader Role/RoleBinding. The cluster now includes a status-api that continuously checks the existing fulfillment-worker Service and logs whether fulfillment jobs are stuck or draining, which makes the incident more representative of a real platform workflow.

The verifier preserves the new status resources, keeps the existing RBAC guardrails, and now requires downstream status logs showing recovery through the worker Service after the intended fix.

Validation run:
- bash -n datasets/kubernetes-core/restore-worker-config-access/environment/scripts/bootstrap-cluster
- bash -n datasets/kubernetes-core/restore-worker-config-access/tests/test_worker_config_access.sh
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core
- uvx --from harbor harbor run -p datasets/kubernetes-core/restore-worker-config-access -a oracle, reward 1.0
- git diff --check