### PR TITLE
feat(kubernetes): Add worker autoscaling load generator

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -133,7 +133,7 @@ digest = "sha256:69764053c8cb4b6f170260a77c33dd4ccc90d2d1d471a2581547c273a566e3f
 
 [[tasks]]
 name = "kubeply/repair-worker-hpa-scaling-inputs"
-digest = "sha256:36ad98fd586a1d640504c3da020800987d65db8b434c86038b6ab00816f8b201"
+digest = "sha256:27fdc522043c2da10750e4006d1b9c929ebf57cda6a3774ff1edd7f6e3b73267"
 
 [[tasks]]
 name = "kubeply/repair-cross-namespace-service-discovery"

--- a/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/environment/scripts/bootstrap-cluster
@@ -8,7 +8,7 @@ prepare-kubeconfig
 
 kubectl apply -f /bootstrap/autoscaling.yaml
 
-for deployment in worker api docs; do
+for deployment in worker api worker-loadgen docs; do
   if ! kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=180s; then
     kubectl -n "$namespace" get all,hpa -o wide >&2 || true
     kubectl -n "$namespace" describe deployment "$deployment" >&2 || true
@@ -52,6 +52,7 @@ fi
 worker_deployment_uid="$(kubectl -n "$namespace" get deployment worker -o jsonpath='{.metadata.uid}')"
 api_deployment_uid="$(kubectl -n "$namespace" get deployment api -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}')"
+worker_loadgen_deployment_uid="$(kubectl -n "$namespace" get deployment worker-loadgen -o jsonpath='{.metadata.uid}')"
 worker_service_uid="$(kubectl -n "$namespace" get service worker -o jsonpath='{.metadata.uid}')"
 api_service_uid="$(kubectl -n "$namespace" get service api -o jsonpath='{.metadata.uid}')"
 docs_service_uid="$(kubectl -n "$namespace" get service docs -o jsonpath='{.metadata.uid}')"
@@ -60,7 +61,7 @@ api_hpa_uid="$(kubectl -n "$namespace" get hpa api -o jsonpath='{.metadata.uid}'
 
 kubectl -n "$namespace" patch configmap infra-bench-baseline \
   --type merge \
-  --patch "{\"data\":{\"worker_deployment_uid\":\"${worker_deployment_uid}\",\"api_deployment_uid\":\"${api_deployment_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"worker_service_uid\":\"${worker_service_uid}\",\"api_service_uid\":\"${api_service_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"worker_hpa_uid\":\"${worker_hpa_uid}\",\"api_hpa_uid\":\"${api_hpa_uid}\"}}"
+  --patch "{\"data\":{\"worker_deployment_uid\":\"${worker_deployment_uid}\",\"api_deployment_uid\":\"${api_deployment_uid}\",\"docs_deployment_uid\":\"${docs_deployment_uid}\",\"worker_loadgen_deployment_uid\":\"${worker_loadgen_deployment_uid}\",\"worker_service_uid\":\"${worker_service_uid}\",\"api_service_uid\":\"${api_service_uid}\",\"docs_service_uid\":\"${docs_service_uid}\",\"worker_hpa_uid\":\"${worker_hpa_uid}\",\"api_hpa_uid\":\"${api_hpa_uid}\"}}"
 
 for _ in $(seq 1 60); do
   token_data="$(kubectl -n "$namespace" get secret "$agent_secret" -o jsonpath='{.data.token}' 2>/dev/null || true)"

--- a/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/environment/workspace/bootstrap/autoscaling.yaml
+++ b/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/environment/workspace/bootstrap/autoscaling.yaml
@@ -69,6 +69,7 @@ data:
   worker_deployment_uid: ""
   api_deployment_uid: ""
   docs_deployment_uid: ""
+  worker_loadgen_deployment_uid: ""
   worker_service_uid: ""
   api_service_uid: ""
   docs_service_uid: ""
@@ -102,8 +103,16 @@ spec:
             - sh
             - -c
             - |
-              mkdir -p /www
+              mkdir -p /www/cgi-bin
               echo "worker ready" > /www/ready
+              cat > /www/cgi-bin/work <<'EOF'
+              #!/bin/sh
+              head -c 12000000 /dev/zero | sha256sum >/dev/null
+              echo "Content-Type: text/plain"
+              echo
+              echo "processed"
+              EOF
+              chmod +x /www/cgi-bin/work
               exec httpd -f -p 8080 -h /www
           ports:
             - name: http
@@ -239,6 +248,39 @@ spec:
         target:
           type: Utilization
           averageUtilization: 70
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker-loadgen
+  namespace: processing-team
+  labels:
+    app: worker-loadgen
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker-loadgen
+  template:
+    metadata:
+      labels:
+        app: worker-loadgen
+    spec:
+      containers:
+        - name: loadgen
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              target="http://worker.processing-team.svc.cluster.local/cgi-bin/work"
+              while true; do
+                for _ in 1 2 3 4; do
+                  wget -qO- "$target" >/dev/null 2>&1 || true &
+                done
+                wait
+              done
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/solution/solve.sh
+++ b/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/solution/solve.sh
@@ -20,12 +20,24 @@ for _ in $(seq 1 90); do
     kubectl -n "$namespace" get hpa worker \
       -o jsonpath='{.status.conditions[?(@.type=="ScalingActive")].status}' 2>/dev/null || true
   )"
+  able_to_scale="$(
+    kubectl -n "$namespace" get hpa worker \
+      -o jsonpath='{.status.conditions[?(@.type=="AbleToScale")].status}' 2>/dev/null || true
+  )"
   current_metric="$(
     kubectl -n "$namespace" get hpa worker \
       -o jsonpath='{.status.currentMetrics[0].resource.current.averageUtilization}' 2>/dev/null || true
   )"
+  desired_replicas="$(
+    kubectl -n "$namespace" get hpa worker \
+      -o jsonpath='{.status.desiredReplicas}' 2>/dev/null || true
+  )"
+  ready_replicas="$(
+    kubectl -n "$namespace" get deployment worker \
+      -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true
+  )"
 
-  if [[ "$scaling_active" == "True" && -n "$current_metric" ]]; then
+  if [[ "$scaling_active" == "True" && "$able_to_scale" == "True" && -n "$current_metric" && "${desired_replicas:-0}" -ge 3 && "${ready_replicas:-0}" -ge 3 ]]; then
     exit 0
   fi
 
@@ -33,4 +45,5 @@ for _ in $(seq 1 90); do
 done
 
 kubectl -n "$namespace" describe hpa worker >&2 || true
+kubectl -n "$namespace" get deployment worker -o yaml >&2 || true
 exit 1

--- a/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/tests/test_hpa_inputs.sh
+++ b/datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/tests/test_hpa_inputs.sh
@@ -81,7 +81,9 @@ expect_deployment() {
   [[ "$label" == "$name" && "$selector" == "$name" ]] || fail "deployment/$name labels changed"
   [[ "$image" == "busybox:1.36" ]] || fail "deployment/$name image changed"
   [[ "$port_name" == "http" && "$port" == "8080" ]] || fail "deployment/$name port changed"
-  [[ "$spec_replicas" == "$replicas" && "$ready_replicas" == "$replicas" ]] || fail "deployment/$name replica state changed"
+  if [[ "$replicas" != "dynamic" ]]; then
+    [[ "$spec_replicas" == "$replicas" && "$ready_replicas" == "$replicas" ]] || fail "deployment/$name replica state changed"
+  fi
   [[ "$request_cpu" == "$cpu_request" && "$request_memory" == "$memory_request" ]] || fail "deployment/$name requests changed to ${request_cpu}/${request_memory}"
   [[ "$limit_cpu" == "$cpu_limit" && "$limit_memory" == "$memory_limit" ]] || fail "deployment/$name limits changed to ${limit_cpu}/${limit_memory}"
 }
@@ -143,6 +145,7 @@ done
 expect_uid deployment worker worker_deployment_uid
 expect_uid deployment api api_deployment_uid
 expect_uid deployment docs docs_deployment_uid
+expect_uid deployment worker-loadgen worker_loadgen_deployment_uid
 expect_uid service worker worker_service_uid
 expect_uid service api api_service_uid
 expect_uid service docs docs_service_uid
@@ -154,7 +157,7 @@ service_names="$(kubectl -n "$namespace" get services -o jsonpath='{range .items
 hpa_names="$(kubectl -n "$namespace" get hpa -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 configmap_names="$(kubectl -n "$namespace" get configmaps -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort)"
 
-[[ "$deployment_names" == $'api\ndocs\nworker' ]] || fail "unexpected deployments: $deployment_names"
+[[ "$deployment_names" == $'api\ndocs\nworker\nworker-loadgen' ]] || fail "unexpected deployments: $deployment_names"
 [[ "$service_names" == $'api\ndocs\nworker' ]] || fail "unexpected services: $service_names"
 [[ "$hpa_names" == $'api\nworker' ]] || fail "unexpected HPAs: $hpa_names"
 [[ "$configmap_names" == $'infra-bench-baseline\nkube-root-ca.crt' ]] || fail "unexpected configmaps: $configmap_names"
@@ -169,7 +172,7 @@ unexpected_workloads="$(
 )"
 [[ -z "$unexpected_workloads" ]] || fail "unexpected replacement workloads: $unexpected_workloads"
 
-expect_deployment worker 2 100m 64Mi 500m 128Mi
+expect_deployment worker dynamic 100m 64Mi 500m 128Mi
 expect_deployment api 1 50m 64Mi 250m 128Mi
 expect_deployment docs 1 20m 32Mi 100m 128Mi
 expect_service worker
@@ -177,6 +180,14 @@ expect_service api
 expect_service docs
 expect_hpa worker 2 5 worker 60
 expect_hpa api 1 3 api 70
+
+loadgen_image="$(kubectl -n "$namespace" get deployment worker-loadgen -o jsonpath='{.spec.template.spec.containers[0].image}')"
+loadgen_command="$(kubectl -n "$namespace" get deployment worker-loadgen -o jsonpath='{.spec.template.spec.containers[0].command[*]}')"
+worker_command="$(kubectl -n "$namespace" get deployment worker -o jsonpath='{.spec.template.spec.containers[0].command[*]}')"
+[[ "$loadgen_image" == "busybox:1.36" ]] || fail "worker-loadgen image changed"
+grep -q 'worker.processing-team.svc.cluster.local/cgi-bin/work' <<< "$loadgen_command" \
+  || fail "worker-loadgen target changed"
+grep -q '/www/cgi-bin/work' <<< "$worker_command" || fail "worker workload endpoint changed"
 
 for service in worker api docs; do
   endpoints="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
@@ -188,7 +199,7 @@ while IFS='|' read -r pod_name pod_app owner_kind; do
 
   [[ "$owner_kind" == "ReplicaSet" ]] || fail "unexpected pod ownership for $pod_name"
   case "$pod_app" in
-    worker | api | docs) ;;
+    worker | api | docs | worker-loadgen) ;;
     *) fail "unexpected pod app label for $pod_name: $pod_app" ;;
   esac
 done < <(
@@ -202,14 +213,15 @@ for _ in $(seq 1 90); do
   worker_metric="$(kubectl -n "$namespace" get hpa worker -o jsonpath='{.status.currentMetrics[0].resource.current.averageUtilization}' 2>/dev/null || true)"
   worker_current="$(kubectl -n "$namespace" get hpa worker -o jsonpath='{.status.currentReplicas}' 2>/dev/null || true)"
   worker_desired="$(kubectl -n "$namespace" get hpa worker -o jsonpath='{.status.desiredReplicas}' 2>/dev/null || true)"
+  worker_ready="$(kubectl -n "$namespace" get deployment worker -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
   api_active="$(kubectl -n "$namespace" get hpa api -o jsonpath='{.status.conditions[?(@.type=="ScalingActive")].status}' 2>/dev/null || true)"
 
-  if [[ "$worker_active" == "True" && "$worker_able" == "True" && -n "$worker_metric" && "$worker_current" == "2" && "$worker_desired" == "2" && "$api_active" == "True" ]]; then
-    echo "Worker HPA can evaluate CPU inputs and the healthy API HPA remains active"
+  if [[ "$worker_active" == "True" && "$worker_able" == "True" && -n "$worker_metric" && "${worker_desired:-0}" -ge 3 && "${worker_ready:-0}" -ge 3 && "$api_active" == "True" ]]; then
+    echo "Worker HPA scales the existing worker under load and the healthy API HPA remains active"
     exit 0
   fi
 
   sleep 2
 done
 
-fail "worker HPA did not become active with CPU metrics; active=${worker_active} able=${worker_able} metric=${worker_metric} current=${worker_current} desired=${worker_desired} apiActive=${api_active}"
+fail "worker HPA did not scale under load; active=${worker_active} able=${worker_able} metric=${worker_metric} current=${worker_current} desired=${worker_desired} ready=${worker_ready} apiActive=${api_active}"


### PR DESCRIPTION
Strengthen the repair worker HPA scaling inputs medium task by putting the existing worker under sustained in-cluster load so success means the worker autoscaler actually scales the workload again.

The task still requires the same targeted repair: restore the worker HPA target and restore the worker CPU request so CPU utilization can be evaluated. The cluster now includes a worker-loadgen Deployment that continuously drives an existing CGI work endpoint on the worker Service, which makes the incident closer to a real autoscaling workflow instead of a static HPA status repair.

The verifier preserves the new load generator, keeps the existing HPA and workload guardrails, and now requires the repaired worker HPA to scale the existing worker above the minimum replica count while the healthy API HPA remains active.

Validation run:
- bash -n datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/environment/scripts/bootstrap-cluster
- bash -n datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/tests/test_hpa_inputs.sh
- bash -n datasets/kubernetes-core/repair-worker-hpa-scaling-inputs/solution/solve.sh
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core
- uvx --from harbor harbor run -p datasets/kubernetes-core/repair-worker-hpa-scaling-inputs -a oracle, reward 1.0
- git diff --check