### PR TITLE
feat(kubernetes): Add nightly report archive step

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -181,7 +181,7 @@ digest = "sha256:a22d062edf9109abf20c87e6a5d3145523edd796eee2ad51d186abe49b9329d
 
 [[tasks]]
 name = "kubeply/recover-nightly-report-cronjob"
-digest = "sha256:d0d528d26b8bbe03039ef842854b0b6ac20834d54c427b2365484436cdedd9b4"
+digest = "sha256:540d3cb6836ae79b5e03507622ee1669a7bc094db39e1a6eb018ad243783c39a"
 
 [[tasks]]
 name = "kubeply/repair-report-custom-resource-status"

--- a/datasets/kubernetes-core/recover-nightly-report-cronjob/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/recover-nightly-report-cronjob/environment/scripts/bootstrap-cluster
@@ -12,7 +12,7 @@ prepare-kubeconfig
 
 kubectl apply -f /bootstrap/reporting.yaml
 
-for deployment in report-api docs; do
+for deployment in report-api report-archive docs; do
   if ! kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=240s; then
     kubectl -n "$namespace" get all,configmaps,secrets -o wide >&2 || true
     kubectl -n "$namespace" describe deployment "$deployment" >&2 || true
@@ -20,7 +20,7 @@ for deployment in report-api docs; do
   fi
 done
 
-for service in report-api docs; do
+for service in report-api report-archive docs; do
   for _ in $(seq 1 60); do
     endpoints="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
     if [[ -n "$endpoints" ]]; then
@@ -78,9 +78,12 @@ report_runner_uid="$(kubectl -n "$namespace" get serviceaccount report-runner -o
 report_api_config_uid="$(kubectl -n "$namespace" get configmap report-api-config -o jsonpath='{.metadata.uid}')"
 old_report_api_config_uid="$(kubectl -n "$namespace" get configmap report-api-config-old -o jsonpath='{.metadata.uid}')"
 report_api_content_uid="$(kubectl -n "$namespace" get configmap report-api-content -o jsonpath='{.metadata.uid}')"
+report_archive_content_uid="$(kubectl -n "$namespace" get configmap report-archive-content -o jsonpath='{.metadata.uid}')"
 report_api_token_uid="$(kubectl -n "$namespace" get secret report-api-token -o jsonpath='{.metadata.uid}')"
 report_api_deployment_uid="$(kubectl -n "$namespace" get deployment report-api -o jsonpath='{.metadata.uid}')"
 report_api_service_uid="$(kubectl -n "$namespace" get service report-api -o jsonpath='{.metadata.uid}')"
+report_archive_deployment_uid="$(kubectl -n "$namespace" get deployment report-archive -o jsonpath='{.metadata.uid}')"
+report_archive_service_uid="$(kubectl -n "$namespace" get service report-archive -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}')"
 docs_service_uid="$(kubectl -n "$namespace" get service docs -o jsonpath='{.metadata.uid}')"
 
@@ -93,9 +96,12 @@ kubectl -n "$namespace" create configmap infra-bench-baseline \
   --from-literal=report_api_config_uid="$report_api_config_uid" \
   --from-literal=old_report_api_config_uid="$old_report_api_config_uid" \
   --from-literal=report_api_content_uid="$report_api_content_uid" \
+  --from-literal=report_archive_content_uid="$report_archive_content_uid" \
   --from-literal=report_api_token_uid="$report_api_token_uid" \
   --from-literal=report_api_deployment_uid="$report_api_deployment_uid" \
   --from-literal=report_api_service_uid="$report_api_service_uid" \
+  --from-literal=report_archive_deployment_uid="$report_archive_deployment_uid" \
+  --from-literal=report_archive_service_uid="$report_archive_service_uid" \
   --from-literal=docs_deployment_uid="$docs_deployment_uid" \
   --from-literal=docs_service_uid="$docs_service_uid"
 

--- a/datasets/kubernetes-core/recover-nightly-report-cronjob/environment/workspace/bootstrap/reporting.yaml
+++ b/datasets/kubernetes-core/recover-nightly-report-cronjob/environment/workspace/bootstrap/reporting.yaml
@@ -104,6 +104,14 @@ metadata:
 data:
   ready: report-api-ok
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: report-archive-content
+  namespace: finance-ops
+data:
+  archive: report-archive-ready
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -146,6 +154,53 @@ metadata:
 spec:
   selector:
     app: report-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: report-archive
+  namespace: finance-ops
+  labels:
+    app: report-archive
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: report-archive
+  template:
+    metadata:
+      labels:
+        app: report-archive
+    spec:
+      containers:
+        - name: report-archive
+          image: nginx:1.27
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: report-archive-content
+              mountPath: /usr/share/nginx/html
+              readOnly: true
+      volumes:
+        - name: report-archive-content
+          configMap:
+            name: report-archive-content
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: report-archive
+  namespace: finance-ops
+  labels:
+    app: report-archive
+spec:
+  selector:
+    app: report-archive
   ports:
     - name: http
       port: 80
@@ -234,6 +289,9 @@ spec:
                   fi
                   response="$(wget -qO- "${REPORT_API_URL}")"
                   echo "$response" | grep -q "report-api-ok"
+                  archive_response="$(wget -qO- "http://report-archive.finance-ops.svc.cluster.local/archive")"
+                  echo "$archive_response" | grep -q "report-archive-ready"
+                  echo "nightly report archived"
                   echo "nightly report completed"
               env:
                 - name: REPORT_API_URL

--- a/datasets/kubernetes-core/recover-nightly-report-cronjob/tests/test_nightly_report_cronjob.sh
+++ b/datasets/kubernetes-core/recover-nightly-report-cronjob/tests/test_nightly_report_cronjob.sh
@@ -34,14 +34,14 @@ baseline_value() {
   kubectl -n "$namespace" get configmap "$baseline_configmap" -o jsonpath="{.data.$1}"
 }
 
-for deployment in report-api docs; do
+for deployment in report-api report-archive docs; do
   if ! kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=180s; then
     dump_debug
     exit 1
   fi
 done
 
-for service in report-api docs; do
+for service in report-api report-archive docs; do
   endpoints="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
   if [[ -z "$endpoints" ]]; then
     echo "Service $service has no endpoints" >&2
@@ -50,7 +50,7 @@ for service in report-api docs; do
   fi
 done
 
-for key in nightly_report_uid nightly_backup_uid failed_job_uid backup_job_uid report_runner_uid report_api_config_uid old_report_api_config_uid report_api_content_uid report_api_token_uid report_api_deployment_uid report_api_service_uid docs_deployment_uid docs_service_uid; do
+for key in nightly_report_uid nightly_backup_uid failed_job_uid backup_job_uid report_runner_uid report_api_config_uid old_report_api_config_uid report_api_content_uid report_archive_content_uid report_api_token_uid report_api_deployment_uid report_api_service_uid report_archive_deployment_uid report_archive_service_uid docs_deployment_uid docs_service_uid; do
   if [[ -z "$(baseline_value "$key")" ]]; then
     echo "Baseline ConfigMap is missing $key" >&2
     kubectl -n "$namespace" get configmap "$baseline_configmap" -o yaml || true
@@ -78,9 +78,12 @@ check_uid "ServiceAccount report-runner" "$(kubectl -n "$namespace" get servicea
 check_uid "ConfigMap report-api-config" "$(kubectl -n "$namespace" get configmap report-api-config -o jsonpath='{.metadata.uid}')" report_api_config_uid
 check_uid "ConfigMap report-api-config-old" "$(kubectl -n "$namespace" get configmap report-api-config-old -o jsonpath='{.metadata.uid}')" old_report_api_config_uid
 check_uid "ConfigMap report-api-content" "$(kubectl -n "$namespace" get configmap report-api-content -o jsonpath='{.metadata.uid}')" report_api_content_uid
+check_uid "ConfigMap report-archive-content" "$(kubectl -n "$namespace" get configmap report-archive-content -o jsonpath='{.metadata.uid}')" report_archive_content_uid
 check_uid "Secret report-api-token" "$(kubectl -n "$namespace" get secret report-api-token -o jsonpath='{.metadata.uid}')" report_api_token_uid
 check_uid "Deployment report-api" "$(kubectl -n "$namespace" get deployment report-api -o jsonpath='{.metadata.uid}')" report_api_deployment_uid
 check_uid "Service report-api" "$(kubectl -n "$namespace" get service report-api -o jsonpath='{.metadata.uid}')" report_api_service_uid
+check_uid "Deployment report-archive" "$(kubectl -n "$namespace" get deployment report-archive -o jsonpath='{.metadata.uid}')" report_archive_deployment_uid
+check_uid "Service report-archive" "$(kubectl -n "$namespace" get service report-archive -o jsonpath='{.metadata.uid}')" report_archive_service_uid
 check_uid "Deployment docs" "$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}')" docs_deployment_uid
 check_uid "Service docs" "$(kubectl -n "$namespace" get service docs -o jsonpath='{.metadata.uid}')" docs_service_uid
 
@@ -98,12 +101,12 @@ if [[ "$cronjob_names" != $'nightly-backup\nnightly-report' ]]; then
   exit 1
 fi
 
-if [[ "$deployment_names" != $'docs\nreport-api' || "$service_names" != $'docs\nreport-api' ]]; then
+if [[ "$deployment_names" != $'docs\nreport-api\nreport-archive' || "$service_names" != $'docs\nreport-api\nreport-archive' ]]; then
   echo "Unexpected app resources: deployments=${deployment_names} services=${service_names}" >&2
   exit 1
 fi
 
-expected_configmaps=$'infra-bench-baseline\nkube-root-ca.crt\nreport-api-config\nreport-api-config-old\nreport-api-content'
+expected_configmaps=$'infra-bench-baseline\nkube-root-ca.crt\nreport-api-config\nreport-api-config-old\nreport-api-content\nreport-archive-content'
 if [[ "$configmap_names" != "$expected_configmaps" ]]; then
   echo "Unexpected ConfigMap set: $configmap_names" >&2
   exit 1
@@ -175,6 +178,13 @@ if [[ "$report_container" != "$report_cronjob" \
   exit 1
 fi
 
+archive_image="$(kubectl -n "$namespace" get deployment report-archive -o jsonpath='{.spec.template.spec.containers[0].image}')"
+archive_service_target="$(kubectl -n "$namespace" get service report-archive -o jsonpath='{.spec.ports[0].targetPort}')"
+if [[ "$archive_image" != "nginx:1.27" || "$archive_service_target" != "http" ]]; then
+  echo "Report archive deployment or Service changed unexpectedly" >&2
+  exit 1
+fi
+
 backup_schedule="$(kubectl -n "$namespace" get cronjob "$backup_cronjob" -o jsonpath='{.spec.schedule}')"
 backup_config="$(kubectl -n "$namespace" get cronjob "$backup_cronjob" -o jsonpath='{.spec.jobTemplate.spec.template.spec.containers[0].name}')"
 backup_job_succeeded="$(kubectl -n "$namespace" get job "$backup_job" -o jsonpath='{.status.succeeded}')"
@@ -224,7 +234,9 @@ while IFS= read -r job_name; do
     continue
   fi
 
-  if [[ "$job_config_ref" == "report-api-config" && "$job_succeeded" == "1" ]] && grep -q "nightly report completed" <<< "$job_log"; then
+  if [[ "$job_config_ref" == "report-api-config" && "$job_succeeded" == "1" ]] \
+    && grep -q "nightly report archived" <<< "$job_log" \
+    && grep -q "nightly report completed" <<< "$job_log"; then
     successful_report_jobs=$((successful_report_jobs + 1))
   elif [[ "$job_config_ref" == "report-api-config-old" && "$job_failed" == "1" ]]; then
     :
@@ -244,4 +256,4 @@ if [[ "$successful_report_jobs" -lt 1 ]]; then
   exit 1
 fi
 
-echo "Nightly report CronJob produced a successful run with preserved history"
+echo "Nightly report CronJob produced a successful archived report with preserved history"


### PR DESCRIPTION
Strengthen the recover nightly report CronJob medium task by extending the existing nightly workflow with an in-cluster archive step.

The intended fix stays the same: repair the nightly report CronJob so it uses the live report API configuration again. The cluster now includes a report-archive Deployment and Service, and the repaired CronJob must progress far enough through the scheduled workflow to archive the report after the API call succeeds. This makes the task less like a bare CronJob exit-code repair and more like a real scheduled report pipeline.

The verifier preserves the new archive resources, keeps the existing schedule and history guardrails, and now requires the successful repaired Job logs to show both archival and completion while prior failed history remains intact.

Validation run:
- bash -n datasets/kubernetes-core/recover-nightly-report-cronjob/environment/scripts/bootstrap-cluster
- bash -n datasets/kubernetes-core/recover-nightly-report-cronjob/tests/test_nightly_report_cronjob.sh
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core
- uvx --from harbor harbor run -p datasets/kubernetes-core/recover-nightly-report-cronjob -a oracle, reward 1.0
- git diff --check