### PR TITLE
feat(kubernetes): Add log panel incident monitor

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -177,7 +177,7 @@ digest = "sha256:0b315dc0dee39ee268ab4e1bd33df566400abb2628fc75dae7ea560ba869f42
 
 [[tasks]]
 name = "kubeply/restore-grafana-logs-datasource"
-digest = "sha256:a22d062edf9109abf20c87e6a5d3145523edd796eee2ad51d186abe49b9329d1"
+digest = "sha256:4162d0d73da85f799ca68e6f6256769c8022c1d4568f2d2f982fd2041c3c882b"
 
 [[tasks]]
 name = "kubeply/recover-nightly-report-cronjob"

--- a/datasets/kubernetes-core/restore-grafana-logs-datasource/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/restore-grafana-logs-datasource/environment/scripts/bootstrap-cluster
@@ -8,7 +8,7 @@ prepare-kubeconfig
 
 kubectl apply -f /bootstrap/observability.yaml
 
-for deployment in logs-backend metrics-backend observability-ui docs demo-api; do
+for deployment in logs-backend metrics-backend observability-ui incident-monitor docs demo-api; do
   if ! kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=240s; then
     kubectl -n "$namespace" get all,configmaps,secrets -o wide >&2 || true
     kubectl -n "$namespace" describe deployment "$deployment" >&2 || true
@@ -46,6 +46,7 @@ fi
 
 ui_deployment_uid="$(kubectl -n "$namespace" get deployment observability-ui -o jsonpath='{.metadata.uid}')"
 ui_service_uid="$(kubectl -n "$namespace" get service observability-ui -o jsonpath='{.metadata.uid}')"
+incident_monitor_deployment_uid="$(kubectl -n "$namespace" get deployment incident-monitor -o jsonpath='{.metadata.uid}')"
 logs_backend_deployment_uid="$(kubectl -n "$namespace" get deployment logs-backend -o jsonpath='{.metadata.uid}')"
 logs_backend_service_uid="$(kubectl -n "$namespace" get service logs-backend -o jsonpath='{.metadata.uid}')"
 docs_deployment_uid="$(kubectl -n "$namespace" get deployment docs -o jsonpath='{.metadata.uid}')"
@@ -66,6 +67,7 @@ kubectl -n "$namespace" patch configmap infra-bench-baseline \
   "data": {
     "ui_deployment_uid": "${ui_deployment_uid}",
     "ui_service_uid": "${ui_service_uid}",
+    "incident_monitor_deployment_uid": "${incident_monitor_deployment_uid}",
     "logs_backend_deployment_uid": "${logs_backend_deployment_uid}",
     "logs_backend_service_uid": "${logs_backend_service_uid}",
     "docs_deployment_uid": "${docs_deployment_uid}",

--- a/datasets/kubernetes-core/restore-grafana-logs-datasource/environment/workspace/bootstrap/observability.yaml
+++ b/datasets/kubernetes-core/restore-grafana-logs-datasource/environment/workspace/bootstrap/observability.yaml
@@ -83,6 +83,7 @@ metadata:
 data:
   ui_deployment_uid: ""
   ui_service_uid: ""
+  incident_monitor_deployment_uid: ""
   logs_backend_deployment_uid: ""
   logs_backend_service_uid: ""
   docs_deployment_uid: ""
@@ -301,6 +302,41 @@ spec:
     - name: http
       port: 3000
       targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: incident-monitor
+  namespace: product-observability
+  labels:
+    app: incident-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: incident-monitor
+  template:
+    metadata:
+      labels:
+        app: incident-monitor
+    spec:
+      containers:
+        - name: incident-monitor
+          image: busybox:1.36.1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              ui_url="http://observability-ui.product-observability.svc.cluster.local:3000/panels"
+              while true; do
+                if wget -qO- "$ui_url" 2>/dev/null | grep -q "logs-ready"; then
+                  echo "incident monitor confirmed log panels via ${ui_url}"
+                else
+                  echo "incident monitor waiting for log panels via ${ui_url}" >&2
+                fi
+                sleep 4
+              done
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/datasets/kubernetes-core/restore-grafana-logs-datasource/tests/test_grafana_logs_datasource.sh
+++ b/datasets/kubernetes-core/restore-grafana-logs-datasource/tests/test_grafana_logs_datasource.sh
@@ -58,6 +58,7 @@ secret_file() {
 
 expect_uid deployment observability-ui ui_deployment_uid
 expect_uid service observability-ui ui_service_uid
+expect_uid deployment incident-monitor incident_monitor_deployment_uid
 expect_uid deployment logs-backend logs_backend_deployment_uid
 expect_uid service logs-backend logs_backend_service_uid
 expect_uid deployment docs docs_deployment_uid
@@ -72,7 +73,7 @@ expect_uid configmap metrics-backend-content metrics_backend_content_uid
 expect_uid serviceaccount observability-ui ui_serviceaccount_uid
 
 deployments="$(kubectl -n "$namespace" get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
-[[ "$deployments" == "demo-api docs logs-backend metrics-backend observability-ui " ]] || fail "unexpected Deployments: $deployments"
+[[ "$deployments" == "demo-api docs incident-monitor logs-backend metrics-backend observability-ui " ]] || fail "unexpected Deployments: $deployments"
 
 services="$(kubectl -n "$namespace" get services -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | sort | tr '\n' ' ')"
 [[ "$services" == "demo-api docs logs-backend metrics-backend observability-ui " ]] || fail "unexpected Services: $services"
@@ -91,7 +92,7 @@ done
 bare_pods="$(kubectl -n "$namespace" get pods -o jsonpath='{range .items[?(@.metadata.ownerReferences[0].kind!="ReplicaSet")]}{.metadata.name}{"\n"}{end}')"
 [[ -z "$bare_pods" ]] || fail "standalone pods are not allowed: $bare_pods"
 
-for deployment in observability-ui logs-backend metrics-backend docs demo-api; do
+for deployment in observability-ui incident-monitor logs-backend metrics-backend docs demo-api; do
   kubectl -n "$namespace" rollout status "deployment/${deployment}" --timeout=120s \
     || fail "deployment/${deployment} did not complete rollout"
 done
@@ -122,6 +123,8 @@ ui_sa="$(kubectl -n "$namespace" get deployment observability-ui -o jsonpath='{.
 ui_port="$(kubectl -n "$namespace" get deployment observability-ui -o jsonpath='{.spec.template.spec.containers[0].ports[0].containerPort}')"
 ui_secret="$(kubectl -n "$namespace" get deployment observability-ui -o jsonpath='{.spec.template.spec.volumes[0].secret.secretName}')"
 ui_mount="$(kubectl -n "$namespace" get deployment observability-ui -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[0].mountPath}')"
+incident_monitor_image="$(kubectl -n "$namespace" get deployment incident-monitor -o jsonpath='{.spec.template.spec.containers[0].image}')"
+incident_monitor_command="$(kubectl -n "$namespace" get deployment incident-monitor -o jsonpath='{.spec.template.spec.containers[0].command[*]}')"
 logs_backend_image="$(kubectl -n "$namespace" get deployment logs-backend -o jsonpath='{.spec.template.spec.containers[0].image}')"
 logs_backend_service_port="$(kubectl -n "$namespace" get service logs-backend -o jsonpath='{.spec.ports[0].port}')"
 logs_backend_target_port="$(kubectl -n "$namespace" get service logs-backend -o jsonpath='{.spec.ports[0].targetPort}')"
@@ -134,6 +137,9 @@ metrics_backend_target_port="$(kubectl -n "$namespace" get service metrics-backe
 [[ "$ui_port" == "3000" ]] || fail "observability UI container port changed"
 [[ "$ui_secret" == "observability-datasources" ]] || fail "observability UI datasource Secret mount changed"
 [[ "$ui_mount" == "/etc/observability-ui/provisioning/datasources" ]] || fail "observability UI datasource mount path changed"
+[[ "$incident_monitor_image" == "busybox:1.36.1" ]] || fail "incident monitor image changed"
+grep -q 'observability-ui.product-observability.svc.cluster.local:3000/panels' <<< "$incident_monitor_command" \
+  || fail "incident monitor dependency path changed"
 [[ "$logs_backend_image" == "nginx:1.27" ]] || fail "logging backend image changed"
 [[ "$logs_backend_service_port" == "3100" && "$logs_backend_target_port" == "http" ]] || fail "logging backend Service port changed"
 [[ "$metrics_backend_image" == "nginx:1.27" ]] || fail "metrics backend image changed"
@@ -148,11 +154,12 @@ for service in docs demo-api; do
 done
 
 for _ in $(seq 1 90); do
-  if kubectl -n "$namespace" logs deployment/observability-ui --tail=80 2>/dev/null | grep -q "log panels ready via ${expected_url}"; then
+  if kubectl -n "$namespace" logs deployment/observability-ui --tail=80 2>/dev/null | grep -q "log panels ready via ${expected_url}" \
+    && kubectl -n "$namespace" logs deployment/incident-monitor --tail=80 2>/dev/null | grep -q 'incident monitor confirmed log panels via http://observability-ui.product-observability.svc.cluster.local:3000/panels'; then
     echo "observability UI log panels recovered through the in-cluster datasource"
     exit 0
   fi
   sleep 1
 done
 
-fail "observability UI logs do not show successful datasource recovery"
+fail "observability UI or downstream incident monitor logs do not show successful datasource recovery"


### PR DESCRIPTION
Strengthen the restore Grafana logs datasource medium task by adding a downstream incident monitor that depends on the observability UI panel state.

The intended fix is still the same: repair the logs datasource so the existing UI can query the in-cluster logging backend again. The cluster now includes an incident-monitor Deployment that watches the existing observability-ui panel endpoint and logs whether log panels are available, which makes the incident more representative of a real consumer workflow instead of only validating the datasource secret in isolation.

The verifier preserves the new monitor, keeps the existing datasource and routing guardrails, and now requires both the UI and the downstream monitor to show recovered log panels through the intended in-cluster path.

Validation run:
- bash -n datasets/kubernetes-core/restore-grafana-logs-datasource/environment/scripts/bootstrap-cluster
- bash -n datasets/kubernetes-core/restore-grafana-logs-datasource/tests/test_grafana_logs_datasource.sh
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core
- uvx --from harbor harbor run -p datasets/kubernetes-core/restore-grafana-logs-datasource -a oracle, reward 1.0
- git diff --check
