### PR TITLE
feat(kubernetes): Add reporting page dependency

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -113,7 +113,7 @@ digest = "sha256:277074c8abeeb7ad119faf54e5d9e66d0eaeb76506da7f7559c9d35187837ba
 
 [[tasks]]
 name = "kubeply/schedule-reporting-api-on-labeled-node"
-digest = "sha256:ed4387d266f68bac86e26ecf23d67ef32c8cae13deeb180843015507a71efe6f"
+digest = "sha256:cc30c51599f18c8e6a081104ba76d4a3be54223022fe4cd88bbc685031c35317"
 
 [[tasks]]
 name = "kubeply/stabilize-cpu-throttled-worker"

--- a/datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/environment/scripts/bootstrap-cluster
+++ b/datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/environment/scripts/bootstrap-cluster
@@ -21,6 +21,14 @@ if kubectl -n "$namespace" rollout status deployment/reporting-api --timeout=20s
   exit 1
 fi
 
+for _ in $(seq 1 60); do
+  if kubectl -n "$namespace" logs deployment/web-api --tail=20 2>/dev/null \
+    | grep -q 'web api waiting for reporting pages via http://reporting-api.analytics-platform.svc.cluster.local/ready'; then
+    break
+  fi
+  sleep 1
+done
+
 reporting_deployment_uid="$(
   kubectl -n "$namespace" get deployment reporting-api -o jsonpath='{.metadata.uid}'
 )"

--- a/datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/environment/workspace/bootstrap/app.yaml
+++ b/datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/environment/workspace/bootstrap/app.yaml
@@ -179,10 +179,22 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eu
               mkdir -p /www
               echo "ok" > /www/ready
-              echo "web api healthy"
-              httpd -f -p 8080 -h /www
+              echo "reporting pages unavailable" > /www/status
+              httpd -f -p 8080 -h /www &
+              reporting_url="http://reporting-api.analytics-platform.svc.cluster.local/ready"
+              while true; do
+                if wget -qO- "$reporting_url" 2>/dev/null | grep -q '^ok$'; then
+                  echo "reporting pages ready" > /www/status
+                  echo "web api serving reporting pages via ${reporting_url}"
+                else
+                  echo "reporting pages unavailable" > /www/status
+                  echo "web api waiting for reporting pages via ${reporting_url}" >&2
+                fi
+                sleep 4
+              done
           ports:
             - name: http
               containerPort: 8080

--- a/datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/tests/test_reporting_node_placement.sh
+++ b/datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/tests/test_reporting_node_placement.sh
@@ -21,6 +21,9 @@ dump_debug() {
     echo "### reporting pods"
     kubectl -n "$namespace" describe pods -l app=reporting-api || true
     echo
+    echo "### web-api logs"
+    kubectl -n "$namespace" logs deployment/web-api --tail=120 || true
+    echo
     echo "### events"
     kubectl -n "$namespace" get events --sort-by=.lastTimestamp || true
   } > /logs/verifier/debug.log 2>&1
@@ -91,6 +94,7 @@ cpu_request="$(kubectl -n "$namespace" get deployment reporting-api -o jsonpath=
 memory_request="$(kubectl -n "$namespace" get deployment reporting-api -o jsonpath='{.spec.template.spec.containers[0].resources.requests.memory}')"
 node_selector="$(kubectl -n "$namespace" get deployment reporting-api -o go-template='{{ index .spec.template.spec.nodeSelector "kubeply.node/pool" }}')"
 toleration="$(kubectl -n "$namespace" get deployment reporting-api -o jsonpath='{range .spec.template.spec.tolerations[*]}{.key}={.value}:{.effect}{"\n"}{end}')"
+web_command="$(kubectl -n "$namespace" get deployment web-api -o jsonpath='{.spec.template.spec.containers[0].command[*]}')"
 
 [[ "$image" == "busybox:1.36.1" ]] || fail "reporting image changed"
 [[ "$replicas" == "2" ]] || fail "reporting replica count changed"
@@ -100,6 +104,8 @@ toleration="$(kubectl -n "$namespace" get deployment reporting-api -o jsonpath='
 [[ "$node_selector" == "reporting" ]] || fail "reporting node selector was not repaired"
 echo "$toleration" | grep -qx 'kubeply.node/pool=reporting:NoSchedule' \
   || fail "reporting toleration was not repaired"
+grep -q 'reporting-api.analytics-platform.svc.cluster.local/ready' <<< "$web_command" \
+  || fail "web-api reporting dependency path changed"
 
 for deployment in reporting-api web-api docs-api; do
   kubectl -n "$namespace" rollout status "deployment/${deployment}" --timeout=120s \
@@ -124,4 +130,17 @@ for service in reporting-api web-api docs-api; do
   [[ -n "$endpoints" ]] || fail "service/$service has no ready endpoints"
 done
 
-echo "reporting-api scheduled on the intended node"
+for _ in $(seq 1 90); do
+  if kubectl -n "$namespace" logs deployment/web-api --tail=80 2>/dev/null \
+    | grep -q 'web api serving reporting pages via http://reporting-api.analytics-platform.svc.cluster.local/ready'; then
+    break
+  fi
+  sleep 1
+done
+
+if ! kubectl -n "$namespace" logs deployment/web-api --tail=100 2>/dev/null \
+  | grep -q 'web api serving reporting pages via http://reporting-api.analytics-platform.svc.cluster.local/ready'; then
+  fail "web-api logs do not show restored reporting pages through the reporting-api Service"
+fi
+
+echo "reporting-api scheduled on the intended node and reporting pages recovered"


### PR DESCRIPTION
Strengthen the schedule reporting API on labeled node medium task by making the existing web-api depend on reporting-api through the in-cluster Service path.

The intended fix stays the same: repair the reporting-api placement constraints so it can schedule onto the labeled and tainted reporting node. The cluster now makes that placement failure show up as a user-facing workflow issue because web-api continuously checks the existing reporting-api Service and logs whether reporting pages are available.

The verifier keeps the node label, taint, identity, and placement guardrails, and now also requires web-api logs showing restored reporting pages through the reporting-api Service after the intended scheduling repair.

Validation run:
- bash -n datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/environment/scripts/bootstrap-cluster
- bash -n datasets/kubernetes-core/schedule-reporting-api-on-labeled-node/tests/test_reporting_node_placement.sh
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core
- uvx --from harbor harbor run -p datasets/kubernetes-core/schedule-reporting-api-on-labeled-node -a oracle, reward 1.0
- git diff --check