### PR TITLE
[codex] Document task planning workflow

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -10,6 +10,26 @@ understand, run, and version deliberately.
 | `kubeply/kubernetes-core` | `datasets/kubernetes-core` | Kubernetes operator benchmark tasks. |
 | `kubeply/terraform-core` | `datasets/terraform-core` | Terraform infrastructure-as-code benchmark tasks. |
 
+## Planning Tasks
+
+Before implementing a new task, decide how it fits the dataset plan.
+
+1. Confirm the dataset release or difficulty plan already has room for the
+   scenario and that the intended outcome does not duplicate another task.
+2. Write a task design brief before implementation starts. The design brief
+   should capture the operator story, broken starting state, hidden diagnosis,
+   expected solution shape, verifier strategy, oracle strategy, metadata, and
+   validation commands.
+3. Track the scenario in its own issue and connect it to the relevant planning
+   issue as a GitHub sub-issue.
+4. Label the scenario issue with:
+   - the release label, such as `v1`
+   - the difficulty label, such as `easy`, `medium`, or `hard`
+   - one dataset-specific coverage-area label, such as `area:service-routing`
+
+Implementation should follow the issue-backed design brief, not invent the task
+shape on the fly.
+
 ## Adding a Task
 
 1. Choose the target dataset directory:

--- a/docs/project.md
+++ b/docs/project.md
@@ -34,3 +34,21 @@ minimal change, and leave the system in a verifiably correct condition.
 
 Prefer a small number of high-signal tasks over a large catalog of shallow
 examples.
+
+## Planning Workflow
+
+Plan dataset releases deliberately instead of adding benchmark tasks ad hoc.
+
+- Define scenario sets before implementation starts, especially when planning a
+  new dataset version or a new difficulty tier.
+- Use one planning issue per dataset release and difficulty tier so the intended
+  task matrix is visible before implementation begins.
+- Track each approved scenario in its own issue with a task design brief before
+  opening implementation PRs.
+- Label task-planning issues with the release label, the difficulty label, and
+  one dataset-specific coverage-area label such as `area:service-routing`.
+- Attach scenario issues as sub-issues of the relevant planning issue so GitHub
+  reflects the intended hierarchy.
+
+Keep this planning workflow repository-wide. Domain-specific difficulty
+calibration and authoring rules still belong in `docs/task-rules/<domain>.md`.


### PR DESCRIPTION
Document the repository-wide planning workflow for dataset work.

This adds two small documentation updates:

- `docs/project.md` now describes the planning flow for release and difficulty buckets, scenario issues, coverage-area labels, and GitHub sub-issue hierarchy
- `docs/datasets.md` now makes task planning explicit before implementation, including the need for a design brief and issue-backed task tracking

These rules were already being applied in practice while defining the hard-task backlog, but they were not written down in the repository. Capturing them now reduces drift as new datasets and future difficulty tiers are planned.
