### PR TITLE
docs: document conventional commit requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ docs/
     `-- kubernetes.md
 ```
 
+## Commit Messages
+
+Use Conventional Commits for all commits. Prefer scopes that match the area
+being changed, such as `feat(kubernetes-core): ...`, `fix(kubernetes-core): ...`,
+`chore(deps): ...`, or `docs: ...`.
+
 ## Validation
 
 Before considering a change complete:


### PR DESCRIPTION
## Summary

- Document that commits in this repo must use Conventional Commits.
- Add examples for common scopes and types used in this repository.

## Validation

- `./scripts/validate-structure.sh`
- `git diff --check`
