### PR TITLE
fix(kubernetes-core): tighten web rollout prompt

### DIFF
--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -213,7 +213,7 @@ digest = "sha256:0ee7c767000aa9f32049fe174ef8483ee825118e559a4f308b2c575ef6bb698
 
 [[tasks]]
 name = "kubeply/recover-web-rollout-after-bad-release"
-digest = "sha256:80c46cef49adfba3a4c9e9c8a08d7bdf0823046f2970332eaa14a44afc1c735b"
+digest = "sha256:d4c8634267c873eeddd64bdcfbb80e69dcb8ed9e8e398cd2d86ff5e416ace2b3"
 
 [[tasks]]
 name = "kubeply/coordinate-secret-rotation-rollout"

--- a/datasets/kubernetes-core/recover-web-rollout-after-bad-release/instruction.md
+++ b/datasets/kubernetes-core/recover-web-rollout-after-bad-release/instruction.md
@@ -7,8 +7,8 @@ A Kubernetes cluster is already running and `kubectl` is configured through
 `KUBECONFIG`.
 
 The public web release is stuck, and users intermittently fail through the
-normal route. Some services in the namespace are healthy, so do not assume the
-whole namespace is broken.
+normal route. The incident does not appear to affect every workload in the
+namespace.
 
 Use `kubectl` to inspect the `market-portal` namespace and restore the existing
 web application while keeping its service contract intact.
@@ -16,13 +16,13 @@ web application while keeping its service contract intact.
 Constraints:
 
 - Use `kubectl` to inspect the live resources before changing anything.
-- Preserve the existing application resources, selectors, images, replica
-  counts, and release identity unless live evidence points to targeted fields
-  that need repair.
+- Preserve the existing application identity and service contract; make only
+  targeted changes supported by live evidence.
 - Do not delete and recreate application resources or the namespace.
 - Do not create replacement workloads or bypass resources.
-- Do not change the healthy admin or docs services.
+- Do not make unrelated workload changes.
 - Do not patch status or write verifier artifacts directly.
 
 Success means the existing web route serves traffic from the intended release
-while the unrelated workloads remain healthy.
+without replacing workloads, rolling back to the old ReplicaSet, or disrupting
+unrelated workloads.


### PR DESCRIPTION
## Summary

- Tightens the `recover-web-rollout-after-bad-release` agent instruction after PR #174 merged.
- Removes explicit `admin`/`docs` healthy workload hints and replaces them with generic unrelated-workload preservation language.
- Refreshes the `kubeply/recover-web-rollout-after-bad-release` digest in `datasets/kubernetes-core/dataset.toml`.

## Validation

- PASS: `bash -n datasets/kubernetes-core/recover-web-rollout-after-bad-release/environment/scripts/*`
- PASS: `bash -n datasets/kubernetes-core/recover-web-rollout-after-bad-release/tests/*.sh`
- PASS: `bash -n datasets/kubernetes-core/recover-web-rollout-after-bad-release/solution/solve.sh`
- PASS: `./scripts/validate-structure.sh`
- PASS: `python3 scripts/lint-kubernetes-rbac.py`
- PASS: `uvx --from harbor harbor sync datasets/kubernetes-core`
- PASS: `python3 scripts/check-dataset-manifests.py datasets/kubernetes-core`
- PASS: `git diff --check`
