### PR TITLE
[codex] Harden hard Kubernetes task verifiers

### DIFF
--- a/datasets/kubernetes-core/complete-node-pool-drain-migration/solution/solve.sh
+++ b/datasets/kubernetes-core/complete-node-pool-drain-migration/solution/solve.sh
@@ -18,6 +18,29 @@ kubectl -n "$namespace" patch deployment checkout-api \
 
 kubectl -n "$namespace" rollout status deployment/checkout-api --timeout=300s
 
+evict_non_daemon_pods_on_retiring_node() {
+  local pod
+
+  while IFS='|' read -r pod owner_kind node_name; do
+    [[ -z "$pod" ]] && continue
+    [[ "$node_name" == "$retiring_node" && "$owner_kind" != "DaemonSet" ]] || continue
+
+    cat <<EOF | kubectl create --raw "/api/v1/namespaces/${namespace}/pods/${pod}/eviction" -f - >/dev/null
+{"apiVersion":"policy/v1","kind":"Eviction","metadata":{"name":"${pod}","namespace":"${namespace}"}}
+EOF
+  done < <(
+    kubectl -n "$namespace" get pods \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.ownerReferences[0].kind}{"|"}{.spec.nodeName}{"\n"}{end}'
+  )
+}
+
+remaining_retiring_pods() {
+  kubectl -n "$namespace" get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.ownerReferences[0].kind}{"|"}{.spec.nodeName}{"\n"}{end}' \
+    | awk -F'|' -v node="$retiring_node" '$3 == node && $2 != "DaemonSet" {print $1}'
+}
+
+migrated="false"
 for _ in $(seq 1 120); do
   checkout_ready="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)"
   checkout_allowed="$(kubectl -n "$namespace" get pdb checkout-api -o jsonpath='{.status.disruptionsAllowed}' 2>/dev/null || true)"
@@ -28,6 +51,22 @@ for _ in $(seq 1 120); do
   )"
 
   if [[ "$checkout_ready" == "3" && "$checkout_allowed" -ge 1 && "$checkout_on_retiring" == "0" ]]; then
+    evict_non_daemon_pods_on_retiring_node
+    migrated="true"
+    break
+  fi
+
+  sleep 2
+done
+
+[[ "$migrated" == "true" ]] || {
+  kubectl get nodes -o wide >&2 || true
+  kubectl -n "$namespace" get pods,pdb -o wide >&2 || true
+  exit 1
+}
+
+for _ in $(seq 1 120); do
+  if [[ -z "$(remaining_retiring_pods)" ]]; then
     exit 0
   fi
 

--- a/datasets/kubernetes-core/complete-node-pool-drain-migration/tests/test_node_pool_migration.sh
+++ b/datasets/kubernetes-core/complete-node-pool-drain-migration/tests/test_node_pool_migration.sh
@@ -103,6 +103,12 @@ expect_single_container_deployment() {
   [[ "$affinity_pool" == "$node_pool" ]] || fail "deployment/$name affinity changed to $affinity_pool"
 }
 
+non_daemon_pods_on_retiring_node() {
+  kubectl -n "$namespace" get pods \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.ownerReferences[0].kind}{"|"}{.spec.nodeName}{"\n"}{end}' \
+    | awk -F'|' -v node="$retiring_node" '$3 == node && $2 != "DaemonSet" {print $1}'
+}
+
 for deployment in checkout-api catalog-api docs; do
   kubectl -n "$namespace" rollout status deployment/"$deployment" --timeout=240s \
     || fail "deployment/$deployment is not ready"
@@ -220,6 +226,8 @@ checkout_on_target="$(
 )"
 [[ "$checkout_on_retiring" == "0" ]] || fail "checkout-api still has pods on $retiring_node"
 [[ "$checkout_on_target" == "3" ]] || fail "checkout-api pods did not settle on the target pool"
+remaining_retiring_pods="$(non_daemon_pods_on_retiring_node)"
+[[ -z "$remaining_retiring_pods" ]] || fail "non-DaemonSet pods still remain on $retiring_node: $remaining_retiring_pods"
 
 for service in checkout-api catalog-api docs; do
   endpoints="$(kubectl -n "$namespace" get endpoints "$service" -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null || true)"
@@ -249,8 +257,9 @@ for _ in $(seq 1 150); do
       -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
       | grep -c "^${retiring_node}$" || true
   )"
+  remaining_retiring_pods="$(non_daemon_pods_on_retiring_node)"
 
-  if [[ "$ready_replicas" == "3" && "$checkout_allowed" -ge 1 && "$total_checkout" == "3" && "$checkout_on_retiring" == "0" ]]; then
+  if [[ "$ready_replicas" == "3" && "$checkout_allowed" -ge 1 && "$total_checkout" == "3" && "$checkout_on_retiring" == "0" && -z "$remaining_retiring_pods" ]]; then
     echo "checkout-api migrated off the retiring node, tolerated one eviction, and returned to full readiness"
     exit 0
   fi
@@ -258,4 +267,4 @@ for _ in $(seq 1 150); do
   sleep 2
 done
 
-fail "checkout-api did not recover to full readiness on the target pool after one allowed eviction"
+fail "checkout-api did not recover to full readiness on the target pool after one allowed eviction; remaining_retiring_pods=${remaining_retiring_pods}"

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -213,7 +213,7 @@ digest = "sha256:0ee7c767000aa9f32049fe174ef8483ee825118e559a4f308b2c575ef6bb698
 
 [[tasks]]
 name = "kubeply/repair-report-operator-finalizer-reconcile"
-digest = "sha256:ed7a7ea2441ca9a7ff0b4bcb148b736e418f6d9e311da47991ec50c705c4be0c"
+digest = "sha256:5d83a5bd9ddeb89e648a41fe03d91dfef15fafc2c50c77b693e6365b4f18ad90"
 
 [[tasks]]
 name = "kubeply/stabilize-checkout-autoscaling-under-load"
@@ -221,19 +221,19 @@ digest = "sha256:0a8638a6384ae4a26bc5891d809a98c1be180311e4a562abe36a505386291a3
 
 [[tasks]]
 name = "kubeply/complete-node-pool-drain-migration"
-digest = "sha256:33b8bb3bc03060a9002ec7c6e86e78158679dcd7a7862efd642ca04f56b55e12"
+digest = "sha256:0a0ea268ff771afab5946e078453374b0cebe2097eb2f35293dad0e3d10d74c9"
 
 [[tasks]]
 name = "kubeply/restore-stateful-cache-identity"
-digest = "sha256:ef4d6b37eef530a801f7582e595b2e9c26a8d6b25667790f32ded7abb3adbc1c"
+digest = "sha256:bf1d9f828a3ef905d6e3acc92dfe61bff5b637859fc29681a9a571919b049e17"
 
 [[tasks]]
 name = "kubeply/repair-payment-tenant-network-boundary"
-digest = "sha256:448e9f357d2b13cc6157af0b5b9c09e032aa8f4c719d7486c415c0bd268b2d56"
+digest = "sha256:b853b0c2a658eab7f027a8644efd1abdf0fb732acccba8f80e2e53526f038572"
 
 [[tasks]]
 name = "kubeply/recover-web-rollout-after-bad-release"
-digest = "sha256:d4c8634267c873eeddd64bdcfbb80e69dcb8ed9e8e398cd2d86ff5e416ace2b3"
+digest = "sha256:0cdc801d11ca776300b9eaf3ba00d162a100682278fef982032aa59ac892fc09"
 
 [[tasks]]
 name = "kubeply/coordinate-secret-rotation-rollout"

--- a/datasets/kubernetes-core/recover-web-rollout-after-bad-release/tests/test_web_rollout.sh
+++ b/datasets/kubernetes-core/recover-web-rollout-after-bad-release/tests/test_web_rollout.sh
@@ -129,6 +129,20 @@ web_port="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.templ
 readiness_path="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}')"
 readiness_port="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.port}')"
 readiness_exec="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.exec.command}' 2>/dev/null || true)"
+web_command_shell="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[0].command[0]}')"
+web_command_flag="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[0].command[1]}')"
+web_command_script="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.spec.containers[0].command[2]}')"
+expected_web_command_script="$(
+  cat <<'EOF'
+release="${WEB_RELEASE:-v1}"
+path="${HEALTH_PATH#/}"
+mkdir -p /www
+printf 'web release %s ok\n' "${release}" > /www/index.html
+printf 'web release %s ok\n' "${release}" > "/www/${path}"
+printf 'web release %s health endpoint is /%s\n' "${release}" "${path}"
+exec httpd -f -p 8080 -h /www
+EOF
+)"
 health_path="$(kubectl -n "$namespace" get configmap web-config -o jsonpath='{.data.health_path}')"
 release_id="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.metadata.annotations.release-id}')"
 config_revision="$(kubectl -n "$namespace" get deployment web -o jsonpath='{.spec.template.metadata.annotations.config-revision}')"
@@ -156,6 +170,11 @@ fi
 
 if [[ -n "$readiness_exec" ]]; then
   echo "web readiness probe was replaced with exec" >&2
+  exit 1
+fi
+
+if [[ "$web_command_shell" != "/bin/sh" || "$web_command_flag" != "-c" || "$web_command_script" != "$expected_web_command_script" ]]; then
+  echo "web container command changed unexpectedly" >&2
   exit 1
 fi
 

--- a/datasets/kubernetes-core/repair-payment-tenant-network-boundary/tests/test_payment_tenant_network_boundary.sh
+++ b/datasets/kubernetes-core/repair-payment-tenant-network-boundary/tests/test_payment_tenant_network_boundary.sh
@@ -154,23 +154,23 @@ done
 payment_policy_target="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o jsonpath='{.spec.podSelector.matchLabels.app}')"
 payment_policy_types="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o jsonpath='{.spec.policyTypes[*]}')"
 payment_egress_count="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o go-template='{{len .spec.egress}}')"
-payment_empty_to="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o go-template='{{range .spec.egress}}{{if not .to}}empty{{end}}{{end}}')"
-payment_ip_blocks="$(
-  kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" \
-    -o jsonpath='{range .spec.egress[*].to[*]}{.ipBlock.cidr}{" "}{end}' \
-    | tr -d '[:space:]'
+payment_egress_summary="$(
+  # shellcheck disable=SC2016
+  kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o go-template='{{range .spec.egress}}{{range .to}}{{if .namespaceSelector}}{{range $k, $v := .namespaceSelector.matchLabels}}{{printf "ns:%s=%s;" $k $v}}{{end}}{{end}}{{if .podSelector}}{{range $k, $v := .podSelector.matchLabels}}{{printf "pod:%s=%s;" $k $v}}{{end}}{{end}}{{if .ipBlock}}{{printf "ip:%s;" .ipBlock.cidr}}{{end}}{{end}}{{range .ports}}{{printf "port:%s/%v;" .protocol .port}}{{end}}{{printf "\n"}}{{end}}' \
+    | sort
 )"
-payment_ledger_namespace="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o jsonpath='{.spec.egress[0].to[0].namespaceSelector.matchLabels.tenant\.kubeply\.io/name}')"
-payment_ledger_app="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o jsonpath='{.spec.egress[0].to[0].podSelector.matchLabels.app}')"
-payment_ledger_port="$(kubectl -n "$payment_namespace" get networkpolicy "$payment_policy" -o jsonpath='{.spec.egress[0].ports[0].port}')"
+expected_payment_egress_summary="$(
+  cat <<'EOF'
+ns:kubernetes.io/metadata.name=kube-system;pod:k8s-app=kube-dns;port:UDP/53;port:TCP/53;
+ns:tenant.kubeply.io/name=payments;pod:app=ledger-api;port:TCP/8080;
+EOF
+)"
 [[ "$payment_policy_target" == "payment-worker" && "$payment_policy_types" == "Egress" ]] \
   || fail "payment egress policy target or type changed"
-[[ "$payment_egress_count" -ge 2 && "$payment_egress_count" -le 3 ]] \
-  || fail "payment egress policy should contain only ledger and DNS egress rules"
-[[ -z "$payment_empty_to" && -z "$payment_ip_blocks" ]] \
-  || fail "payment egress policy was broadened"
-[[ "$payment_ledger_namespace" == "payments" && "$payment_ledger_app" == "ledger-api" && "$payment_ledger_port" == "8080" ]] \
-  || fail "payment egress policy no longer targets the intended ledger backend narrowly"
+[[ "$payment_egress_count" == "2" ]] \
+  || fail "payment egress policy should contain exactly ledger and DNS egress rules"
+[[ "$payment_egress_summary" == "$expected_payment_egress_summary" ]] \
+  || fail "payment egress policy was broadened or no longer targets only ledger and DNS; got: $payment_egress_summary"
 
 ledger_policy_target="$(kubectl -n "$ledger_namespace" get networkpolicy "$ledger_policy" -o jsonpath='{.spec.podSelector.matchLabels.app}')"
 ledger_policy_types="$(kubectl -n "$ledger_namespace" get networkpolicy "$ledger_policy" -o jsonpath='{.spec.policyTypes[*]}')"

--- a/datasets/kubernetes-core/repair-report-operator-finalizer-reconcile/tests/test_finalizer_reconcile.sh
+++ b/datasets/kubernetes-core/repair-report-operator-finalizer-reconcile/tests/test_finalizer_reconcile.sh
@@ -239,20 +239,31 @@ grep -q "reconciled Report ${target_report} into ConfigMap ${target_output}" <<<
 
 controller_subject="$(kubectl -n "$namespace" get rolebinding "$controller" -o jsonpath='{.subjects[0].kind}/{.subjects[0].name}')"
 controller_role_ref="$(kubectl -n "$namespace" get rolebinding "$controller" -o jsonpath='{.roleRef.kind}/{.roleRef.name}')"
-controller_configmap_resources="$(kubectl -n "$namespace" get role "$controller" -o jsonpath='{.rules[2].resources[*]}' | tr ' ' '\n' | sort | tr '\n' ' ')"
-controller_configmap_verbs="$(kubectl -n "$namespace" get role "$controller" -o jsonpath='{.rules[2].verbs[*]}' | tr ' ' '\n' | sort | tr '\n' ' ')"
-agent_status_rules="$(kubectl -n "$namespace" get role infra-bench-agent -o jsonpath='{range .rules[?(@.resources[0]=="reports/status")]}{.verbs[*]}{end}' 2>/dev/null || true)"
-agent_configmap_write="$(kubectl -n "$namespace" get role infra-bench-agent -o jsonpath='{.rules[0].verbs[*]}' | tr ' ' '\n' | grep -E '^(create|patch|update|delete|\*)$' || true)"
+controller_rule_count="$(kubectl -n "$namespace" get role "$controller" -o go-template='{{len .rules}}')"
+controller_rules="$(
+  kubectl -n "$namespace" get role "$controller" -o go-template='{{range .rules}}{{range .apiGroups}}{{printf "api:%s;" .}}{{end}}{{range .resources}}{{printf "res:%s;" .}}{{end}}{{range .verbs}}{{printf "verb:%s;" .}}{{end}}{{printf "\n"}}{{end}}' \
+    | sort
+)"
+expected_controller_rules="$(
+  cat <<'EOF'
+api:;res:configmaps;verb:get;verb:list;verb:watch;verb:create;verb:patch;verb:update;verb:delete;
+api:;res:events;verb:create;verb:patch;
+api:platform.infra-bench.dev;res:reports/status;verb:get;verb:patch;verb:update;
+api:platform.infra-bench.dev;res:reports;verb:get;verb:list;verb:watch;verb:patch;verb:update;
+EOF
+)"
+agent_bypass_rules="$(
+  kubectl -n "$namespace" get role infra-bench-agent -o go-template='{{range .rules}}{{range .resources}}{{printf "res:%s;" .}}{{end}}{{range .verbs}}{{printf "verb:%s;" .}}{{end}}{{printf "\n"}}{{end}}' \
+    | awk '/res:reports\/status/ || (/res:configmaps/ && /verb:(create|patch|update|delete|\*)/) {print}' || true
+)"
 extra_controller_clusterrole="$(kubectl get clusterrole report-controller -o name 2>/dev/null || true)"
 extra_controller_clusterrolebinding="$(kubectl get clusterrolebinding report-controller -o name 2>/dev/null || true)"
 
 [[ "$controller_subject" == "ServiceAccount/report-controller" && "$controller_role_ref" == "Role/report-controller" ]] \
   || fail "controller RoleBinding must remain namespaced and bound only to the controller ServiceAccount"
-[[ "$controller_configmap_resources" == "configmaps " ]] \
-  || fail "controller ConfigMap rule must stay scoped to ConfigMaps"
-[[ "$controller_configmap_verbs" == "create delete get list patch update watch " ]] \
-  || fail "controller ConfigMap verbs must be least-privilege, not broad: $controller_configmap_verbs"
-[[ -z "$agent_status_rules" && -z "$agent_configmap_write" ]] \
+[[ "$controller_rule_count" == "4" && "$controller_rules" == "$expected_controller_rules" ]] \
+  || fail "controller Role rules must stay least-privilege and exact; got: $controller_rules"
+[[ -z "$agent_bypass_rules" ]] \
   || fail "agent Role was broadened to bypass controller reconciliation"
 [[ -z "$extra_controller_clusterrole" && -z "$extra_controller_clusterrolebinding" ]] \
   || fail "controller RBAC was broadened to cluster scope"

--- a/datasets/kubernetes-core/restore-stateful-cache-identity/tests/test_restore_stateful_cache_identity.sh
+++ b/datasets/kubernetes-core/restore-stateful-cache-identity/tests/test_restore_stateful_cache_identity.sh
@@ -147,6 +147,10 @@ cache_limit_cpu="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jso
 cache_limit_memory="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}')"
 cache_mount_name="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[0].name}')"
 cache_mount_path="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[0].mountPath}')"
+cache_command_shell="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.containers[0].command[0]}')"
+cache_command_script="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.containers[0].command[1]}')"
+cache_script_mount="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="scripts")].mountPath}')"
+cache_script_volume="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{.spec.template.spec.volumes[?(@.name=="scripts")].configMap.name}')"
 claim_template_names="$(kubectl -n "$namespace" get statefulset "$statefulset" -o jsonpath='{range .spec.volumeClaimTemplates[*]}{.metadata.name}{" "}{end}')"
 
 [[ "$cache_replicas" == "3" && "${cache_ready:-0}" == "3" ]] || fail "cache replica state incorrect"
@@ -157,6 +161,8 @@ claim_template_names="$(kubectl -n "$namespace" get statefulset "$statefulset" -
 [[ "$cache_request_cpu" == "50m" && "$cache_request_memory" == "64Mi" ]] || fail "StatefulSet resource requests changed"
 [[ "$cache_limit_cpu" == "150m" && "$cache_limit_memory" == "128Mi" ]] || fail "StatefulSet resource limits changed"
 [[ "$cache_mount_name" == "data" && "$cache_mount_path" == "/var/lib/session-cache" ]] || fail "cache does not mount the preserved data template"
+[[ "$cache_command_shell" == "/bin/sh" && "$cache_command_script" == "/opt/session-cache/cache.sh" ]] || fail "cache command was changed"
+[[ "$cache_script_mount" == "/opt/session-cache" && "$cache_script_volume" == "session-cache-scripts" ]] || fail "cache script wiring changed"
 [[ "$claim_template_names" == "data restore-data " ]] || fail "volume claim template identities changed"
 
 headless_cluster_ip="$(kubectl -n "$namespace" get service session-cache-peers -o jsonpath='{.spec.clusterIP}')"
@@ -203,10 +209,16 @@ checkout_port_name="$(kubectl -n "$namespace" get deployment checkout-api -o jso
 checkout_port="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.spec.template.spec.containers[0].ports[0].containerPort}')"
 checkout_selector="$(kubectl -n "$namespace" get service checkout-api -o jsonpath='{.spec.selector.app}')"
 checkout_target_port="$(kubectl -n "$namespace" get service checkout-api -o jsonpath='{.spec.ports[0].targetPort}')"
+checkout_command_shell="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.spec.template.spec.containers[0].command[0]}')"
+checkout_command_script="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.spec.template.spec.containers[0].command[1]}')"
+checkout_script_mount="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.spec.template.spec.containers[0].volumeMounts[?(@.name=="scripts")].mountPath}')"
+checkout_script_volume="$(kubectl -n "$namespace" get deployment checkout-api -o jsonpath='{.spec.template.spec.volumes[?(@.name=="scripts")].configMap.name}')"
 
 [[ "${checkout_ready:-0}" == "1" ]] || fail "checkout-api is not Ready"
 [[ "$checkout_image" == "busybox:1.36.1" && "$checkout_port_name" == "http" && "$checkout_port" == "8080" ]] || fail "checkout-api container changed"
 [[ "$checkout_selector" == "checkout-api" && "$checkout_target_port" == "http" ]] || fail "checkout-api Service changed"
+[[ "$checkout_command_shell" == "/bin/sh" && "$checkout_command_script" == "/opt/checkout/checkout.sh" ]] || fail "checkout-api command was changed"
+[[ "$checkout_script_mount" == "/opt/checkout" && "$checkout_script_volume" == "checkout-api-scripts" ]] || fail "checkout-api script wiring changed"
 
 checkout_endpoints="$(kubectl -n "$namespace" get endpoints checkout-api -o jsonpath='{.subsets[*].addresses[*].ip}')"
 docs_endpoints="$(kubectl -n "$namespace" get endpoints docs-site -o jsonpath='{.subsets[*].addresses[*].ip}')"


### PR DESCRIPTION
## Summary

Hardens verifier coverage for the recently added hard Kubernetes Core tasks so common bypasses are rejected before benchmark runs.

- requires exact payment egress NetworkPolicy rules instead of allowing broad extra rules
- verifies the report controller Role as a full exact rule set instead of checking only one indexed rule
- pins the web rollout command script so the task cannot be solved by rewriting the container command
- pins cache and checkout command/script wiring for the StatefulSet cache task
- requires node-pool migration to leave no non-DaemonSet pods on the retiring node, and updates the oracle solution to complete that eviction flow
- refreshes Kubernetes Core dataset digests

## Validation

- `./scripts/lint-files.sh`
- `./scripts/validate-structure.sh`
- `python3 scripts/lint-kubernetes-rbac.py`
- `python3 scripts/check-dataset-manifests.py datasets/kubernetes-core`
- `uvx --from harbor harbor sync datasets/kubernetes-core`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/recover-web-rollout-after-bad-release -a oracle` -> reward `1.0`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/restore-stateful-cache-identity -a oracle` -> reward `1.0`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/repair-payment-tenant-network-boundary -a oracle` -> reward `1.0`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/complete-node-pool-drain-migration -a oracle` -> reward `1.0`
- `uvx --from harbor harbor run -p datasets/kubernetes-core/repair-report-operator-finalizer-reconcile -a oracle` -> reward `1.0`
