### PR TITLE
[codex] Update Kubernetes Core task counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Dataset | 🟢 Easy | 🟡 Medium | 🔴 Hard | Status |
 | --- | ---: | ---: | ---: | --- |
-| [`kubeply/kubernetes-core`](datasets/kubernetes-core) | 22 | 23 | 6 | 🛠️ Working |
+| [`kubeply/kubernetes-core`](datasets/kubernetes-core) | 22 | 23 | 13 | 🛠️ Working |
 | [`kubeply/terraform-core`](datasets/terraform-core) | 0 | 0 | 0 | 🛠️ Working |
 | `kubeply/observability-core` | 0 | 0 | 0 | ⏳ Not started yet |
 


### PR DESCRIPTION
## Summary

Updates the README dataset table after the latest merged Kubernetes Core hard tasks.

- changes `kubeply/kubernetes-core` hard task count from 6 to 13
- keeps easy and medium counts unchanged at 22 and 23

## Validation

- counted `difficulty` values from `datasets/kubernetes-core/*/task.toml`
- `git diff --check`
