### PR TITLE
fix(results): derive durations from timestamps

### DIFF
--- a/scripts/normalize-benchmark-run.py
+++ b/scripts/normalize-benchmark-run.py
@@ -278,6 +278,27 @@ def normalize_timestamp(value: str | None) -> str | None:
     return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
 
 
+def duration_between_timestamps(
+    started_at: str | None,
+    finished_at: str | None,
+) -> float | None:
+    """Compute elapsed seconds from normalized timestamps when possible."""
+
+    if started_at is None or finished_at is None:
+        return None
+
+    try:
+        started = datetime.fromisoformat(started_at.replace("Z", "+00:00"))
+        finished = datetime.fromisoformat(finished_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+    duration = (finished - started).total_seconds()
+    if duration < 0:
+        return None
+    return duration
+
+
 def current_timestamp() -> str:
     """Return the current UTC timestamp without microseconds."""
 
@@ -414,6 +435,8 @@ def normalize_trial(
     finished = normalize_timestamp(
         first_string(combined, {"finished_at", "end_time", "finishedAt"})
     )
+    if duration is None:
+        duration = duration_between_timestamps(started, finished)
     score = max(0.0, min(1.0, reward))
 
     verifier_key = artifact_key(r2_prefix, run_id, task.slug, "verifier-summary.json")

--- a/scripts/test-benchmark-results-normalizer.py
+++ b/scripts/test-benchmark-results-normalizer.py
@@ -72,7 +72,8 @@ def write_fixture_job(root: Path) -> Path:
         {
             "passed": True,
             "reward": 1,
-            "duration_sec": 300,
+            "started_at": "2026-04-26T12:00:00Z",
+            "finished_at": "2026-04-26T12:05:00Z",
             "status": "completed",
         },
     )
@@ -152,6 +153,8 @@ def test_normalizer_writes_public_contract() -> None:
         assert result["task_name"] == "kubeply/restore-multi-hop-checkout-route"
         assert result["difficulty"] == "hard"
         assert result["passed"] is True
+        assert result["duration_sec"] == 300
+        assert run["summary"]["duration_sec"] == 300
         assert "/public/" in result["agent_artifact_key"]
         assert result["agent_artifact_key"].endswith("agent-summary.json")
         assert (


### PR DESCRIPTION
## Summary
- derive task duration from normalized started_at and finished_at timestamps when Harbor does not emit an explicit duration field
- preserve explicit duration values when present
- add regression coverage for derived task and run summary duration

## Verification
- ./scripts/lint-files.sh
- ./scripts/validate-structure.sh
- python3 scripts/test-benchmark-results-normalizer.py
- python3 scripts/lint-kubernetes-rbac.py
- python3 scripts/check-dataset-manifests.py
- /tmp/actionlint/actionlint
