### PR TITLE
fix(results): publish useful benchmark artifacts

### DIFF
--- a/scripts/normalize-benchmark-run.py
+++ b/scripts/normalize-benchmark-run.py
@@ -143,6 +143,14 @@ def read_json_if_present(path: Path) -> dict[str, Any]:
     return load_json(path)
 
 
+def read_text_if_present(path: Path) -> str | None:
+    """Return text file contents when the file exists."""
+
+    if not path.exists():
+        return None
+    return path.read_text(errors="replace")
+
+
 def load_dataset_name(dataset_path: Path) -> str:
     """Read the Harbor dataset name from dataset.toml."""
 
@@ -299,6 +307,15 @@ def duration_between_timestamps(
     return duration
 
 
+def phase_data(data: dict[str, Any], name: str) -> dict[str, Any]:
+    """Return timing phase data when present in a Harbor result."""
+
+    value = data.get(name)
+    if isinstance(value, dict):
+        return value
+    return {}
+
+
 def current_timestamp() -> str:
     """Return the current UTC timestamp without microseconds."""
 
@@ -401,6 +418,12 @@ def artifact_key(prefix: str, run_id: str, task_slug: str, filename: str) -> str
     return f"{prefix}/runs/{run_id}/public/{task_slug}/{filename}"
 
 
+def public_file_key(prefix: str, run_id: str, filename: str) -> str:
+    """Build an R2 object key for a public run artifact."""
+
+    return f"{prefix}/runs/{run_id}/{filename}"
+
+
 def normalize_trial(
     trial_dir: Path,
     tasks: dict[str, TaskMetadata],
@@ -425,15 +448,25 @@ def normalize_trial(
     if passed is None:
         passed = reward >= 1.0
 
-    duration = first_number(
-        combined,
-        {"duration_sec", "duration_seconds", "duration", "elapsed_sec"},
+    agent_execution = phase_data(trial_result, "agent_execution")
+    verifier = phase_data(trial_result, "verifier")
+    duration = first_present(
+        first_number(
+            agent_execution,
+            {"duration_sec", "duration_seconds", "duration", "elapsed_sec"},
+        ),
+        first_number(
+            combined,
+            {"agent_duration_sec", "agent_duration_seconds"},
+        ),
     )
     started = normalize_timestamp(
-        first_string(combined, {"started_at", "start_time", "startedAt"})
+        first_string(agent_execution, {"started_at", "start_time", "startedAt"})
+        or first_string(combined, {"started_at", "start_time", "startedAt"})
     )
     finished = normalize_timestamp(
-        first_string(combined, {"finished_at", "end_time", "finishedAt"})
+        first_string(agent_execution, {"finished_at", "end_time", "finishedAt"})
+        or first_string(combined, {"finished_at", "end_time", "finishedAt"})
     )
     if duration is None:
         duration = duration_between_timestamps(started, finished)
@@ -441,20 +474,42 @@ def normalize_trial(
 
     verifier_key = artifact_key(r2_prefix, run_id, task.slug, "verifier-summary.json")
     agent_key = artifact_key(r2_prefix, run_id, task.slug, "agent-summary.json")
+    verifier_started = normalize_timestamp(
+        first_string(verifier, {"started_at", "start_time", "startedAt"})
+    )
+    verifier_finished = normalize_timestamp(
+        first_string(verifier, {"finished_at", "end_time", "finishedAt"})
+    )
     verifier_summary = {
         "schema_version": SCHEMA_VERSION,
         "task_name": task.name,
         "passed": passed,
         "reward": reward,
         "score": score,
+        "started_at": verifier_started,
+        "finished_at": verifier_finished,
+        "duration_sec": duration_between_timestamps(
+            verifier_started,
+            verifier_finished,
+        ),
         "has_reward_txt": (trial_dir / "verifier" / "reward.txt").exists(),
         "has_reward_json": (trial_dir / "verifier" / "reward.json").exists(),
+        "reward_txt": read_text_if_present(trial_dir / "verifier" / "reward.txt"),
+        "test_log": read_text_if_present(trial_dir / "verifier" / "test.log"),
+        "test_stdout": read_text_if_present(trial_dir / "verifier" / "test-stdout.txt"),
+        "debug_log": read_text_if_present(trial_dir / "verifier" / "debug.log"),
     }
     agent_summary = {
         "schema_version": SCHEMA_VERSION,
         "task_name": task.name,
         "status": first_string(combined, {"status", "state"}),
-        "raw_transcript_public": False,
+        "started_at": started,
+        "finished_at": finished,
+        "duration_sec": duration,
+        "raw_transcript_public": True,
+        "codex_log": read_text_if_present(trial_dir / "agent" / "codex.txt"),
+        "trajectory": read_json_if_present(trial_dir / "agent" / "trajectory.json")
+        or None,
     }
 
     return TrialResult(
@@ -629,8 +684,13 @@ def build_documents(
             "cost_usd": run_cost,
         },
         "artifacts": {
-            "run": f"{args.r2_prefix.strip('/')}/runs/{run_id}/run.json",
-            "results": f"{args.r2_prefix.strip('/')}/runs/{run_id}/results.json",
+            "run": public_file_key(args.r2_prefix.strip("/"), run_id, "run.json"),
+            "results": public_file_key(
+                args.r2_prefix.strip("/"), run_id, "results.json"
+            ),
+            "summary": public_file_key(
+                args.r2_prefix.strip("/"), run_id, "summary.json"
+            ),
             "archive": archive_key,
         },
     }

--- a/scripts/test-benchmark-results-normalizer.py
+++ b/scripts/test-benchmark-results-normalizer.py
@@ -74,11 +74,29 @@ def write_fixture_job(root: Path) -> Path:
             "reward": 1,
             "started_at": "2026-04-26T12:00:00Z",
             "finished_at": "2026-04-26T12:05:00Z",
+            "agent_execution": {
+                "started_at": "2026-04-26T12:01:00Z",
+                "finished_at": "2026-04-26T12:03:00Z",
+            },
+            "verifier": {
+                "started_at": "2026-04-26T12:04:00Z",
+                "finished_at": "2026-04-26T12:04:15Z",
+            },
             "status": "completed",
         },
     )
+    write_json(
+        trial / "agent" / "trajectory.json",
+        {
+            "schema_version": "ATIF-v1.5",
+            "steps": [{"source": "agent", "message": "fixed it"}],
+        },
+    )
+    (trial / "agent" / "codex.txt").write_text("agent transcript\n")
     (trial / "verifier").mkdir()
     (trial / "verifier" / "reward.txt").write_text("1\n")
+    (trial / "verifier" / "test.log").write_text("verifier test log\n")
+    (trial / "verifier" / "test-stdout.txt").write_text("verifier stdout\n")
     return job
 
 
@@ -153,10 +171,27 @@ def test_normalizer_writes_public_contract() -> None:
         assert result["task_name"] == "kubeply/restore-multi-hop-checkout-route"
         assert result["difficulty"] == "hard"
         assert result["passed"] is True
-        assert result["duration_sec"] == 300
-        assert run["summary"]["duration_sec"] == 300
+        assert result["duration_sec"] == 120
+        assert result["started_at"] == "2026-04-26T12:01:00Z"
+        assert result["finished_at"] == "2026-04-26T12:03:00Z"
+        assert run["summary"]["duration_sec"] == 120
+        assert run["artifacts"]["summary"].endswith("/summary.json")
         assert "/public/" in result["agent_artifact_key"]
         assert result["agent_artifact_key"].endswith("agent-summary.json")
+        agent_summary = json.loads(
+            (output / "public" / result["task_slug"] / "agent-summary.json").read_text()
+        )
+        verifier_summary = json.loads(
+            (
+                output / "public" / result["task_slug"] / "verifier-summary.json"
+            ).read_text()
+        )
+        assert agent_summary["raw_transcript_public"] is True
+        assert agent_summary["codex_log"] == "agent transcript\n"
+        assert agent_summary["trajectory"]["schema_version"] == "ATIF-v1.5"
+        assert verifier_summary["duration_sec"] == 15
+        assert verifier_summary["test_log"] == "verifier test log\n"
+        assert verifier_summary["test_stdout"] == "verifier stdout\n"
         assert (
             "INSERT OR REPLACE INTO benchmark_runs"
             in (output / "d1-upsert.sql").read_text()

--- a/scripts/upload-benchmark-r2.py
+++ b/scripts/upload-benchmark-r2.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Upload normalized benchmark JSON artifacts to Cloudflare R2."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+JSON_CONTENT_TYPE = "application/json; charset=utf-8"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments for the R2 uploader."""
+
+    parser = argparse.ArgumentParser(
+        description="Upload normalized benchmark JSON artifacts to R2."
+    )
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--bucket", required=True)
+    parser.add_argument("--r2-prefix", default="benchmarks")
+    parser.add_argument("--local", action="store_true")
+    parser.add_argument("--remote", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def load_run_id(output_dir: Path) -> str:
+    """Read the run id from a normalized run.json file."""
+
+    run_path = output_dir / "run.json"
+    if not run_path.exists():
+        raise SystemExit(f"{run_path}: missing run.json")
+    data = json.loads(run_path.read_text())
+    run_id = data.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        raise SystemExit(f"{run_path}: missing run_id")
+    return run_id
+
+
+def iter_upload_files(output_dir: Path) -> list[Path]:
+    """Return normalized JSON files that should be public R2 artifacts."""
+
+    files = [
+        output_dir / "run.json",
+        output_dir / "results.json",
+        output_dir / "summary.json",
+    ]
+    files.extend(sorted((output_dir / "public").glob("*/*.json")))
+    missing = [path for path in files if not path.exists()]
+    if missing:
+        formatted = "\n".join(str(path) for path in missing)
+        raise SystemExit(f"missing normalized artifact files:\n{formatted}")
+    return files
+
+
+def object_key(output_dir: Path, path: Path, r2_prefix: str, run_id: str) -> str:
+    """Build the R2 object key for one normalized artifact file."""
+
+    relative = path.relative_to(output_dir).as_posix()
+    return f"{r2_prefix.strip('/')}/runs/{run_id}/{relative}"
+
+
+def upload_file(
+    bucket: str,
+    key: str,
+    path: Path,
+    *,
+    local: bool,
+    remote: bool,
+) -> None:
+    """Upload one file to R2 with Wrangler."""
+
+    command = [
+        "wrangler",
+        "r2",
+        "object",
+        "put",
+        f"{bucket}/{key}",
+        "--file",
+        str(path),
+        "--content-type",
+        JSON_CONTENT_TYPE,
+    ]
+    if local:
+        command.append("--local")
+    if remote:
+        command.append("--remote")
+    subprocess.run(command, check=True)
+
+
+def main() -> int:
+    """Run the R2 upload workflow."""
+
+    args = parse_args()
+    output_dir = args.output_dir.resolve()
+    run_id = load_run_id(output_dir)
+    files = iter_upload_files(output_dir)
+
+    for path in files:
+        key = object_key(output_dir, path, args.r2_prefix, run_id)
+        if args.dry_run:
+            print(f"{path} -> r2://{args.bucket}/{key}")
+        else:
+            upload_file(args.bucket, key, path, local=args.local, remote=args.remote)
+
+    action = "would upload" if args.dry_run else "uploaded"
+    print(f"{action} {len(files)} benchmark artifacts to r2://{args.bucket}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- use Harbor agent_execution timestamps for task duration instead of full trial wall-clock time
- enrich public agent summaries with Codex transcript and trajectory data
- enrich public verifier summaries with verifier timing, reward text, test logs, stdout, and debug logs
- add a small R2 uploader for normalized benchmark JSON artifacts
- include summary.json in run artifact metadata

## Verification
- ./scripts/lint-files.sh
- python3 scripts/test-benchmark-results-normalizer.py
- python3 -m py_compile scripts/upload-benchmark-r2.py scripts/normalize-benchmark-run.py scripts/test-benchmark-results-normalizer.py
- ./scripts/upload-benchmark-r2.py --output-dir /tmp/infra-bench-medium-artifact-check --bucket test-bucket --dry-run
- ./scripts/validate-structure.sh
- python3 scripts/lint-kubernetes-rbac.py
- python3 scripts/check-dataset-manifests.py
- /tmp/actionlint/actionlint
