### PR TITLE
docs(results): document benchmark publish commands

### DIFF
--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -35,3 +35,50 @@ Use `--dry-run` to validate and print the normalized JSON without writing files.
 The normalizer writes `run.json`, `results.json`, `summary.json`, public
 per-task summaries, and `d1-upsert.sql`. Apply
 `schemas/benchmark-results/d1.sql` before loading generated D1 upsert files.
+
+## Publish Benchmark Results
+
+Use this workflow after Harbor jobs finish and the normalized results should be
+published to Cloudflare D1 and Cloudflare R2.
+
+Set publish variables from the `infra-bench` repository root:
+
+```bash
+export D1_DB="<cloudflare-d1-database-name>"
+export R2_BUCKET="<cloudflare-r2-bucket-name>"
+export RUN_ID="<stable-run-id>"
+export JOB_DIR="jobs/<harbor-job-name>"
+export DATASET_PATH="datasets/<dataset-name>"
+```
+
+Normalize the Harbor job:
+
+```bash
+scripts/normalize-benchmark-run.py \
+  --job-dir "$JOB_DIR" \
+  --dataset-path "$DATASET_PATH" \
+  --model-provider "<provider>" \
+  --model-name "<model-name>" \
+  --model-version "<model-version-or-effort>" \
+  --run-id "$RUN_ID" \
+  --output-dir "build/benchmark-results/$RUN_ID"
+```
+
+Upsert the compact query rows into remote D1:
+
+```bash
+wrangler d1 execute "$D1_DB" --remote --file "build/benchmark-results/$RUN_ID/d1-upsert.sql"
+```
+
+Upload the normalized JSON artifacts to remote R2:
+
+```bash
+scripts/upload-benchmark-r2.py \
+  --output-dir "build/benchmark-results/$RUN_ID" \
+  --bucket "$R2_BUCKET" \
+  --remote
+```
+
+The D1 upserts use stable run ids, so rerunning this workflow replaces existing
+rows for the same runs. R2 uploads use the same immutable run-scoped object keys
+and are safe to rerun when normalized artifacts are corrected.

--- a/docs/specs/benchmark-results-publishing.md
+++ b/docs/specs/benchmark-results-publishing.md
@@ -110,6 +110,7 @@ latest summaries.
 ```text
 benchmarks/runs/<run_id>/run.json
 benchmarks/runs/<run_id>/results.json
+benchmarks/runs/<run_id>/summary.json
 benchmarks/runs/<run_id>/artifacts.tar.zst
 benchmarks/runs/<run_id>/public/<task-slug>/verifier-summary.json
 benchmarks/runs/<run_id>/public/<task-slug>/agent-summary.json
@@ -151,6 +152,7 @@ cache and must not be treated as the source of truth.
   "artifacts": {
     "run": "benchmarks/runs/<run_id>/run.json",
     "results": "benchmarks/runs/<run_id>/results.json",
+    "summary": "benchmarks/runs/<run_id>/summary.json",
     "archive": "benchmarks/runs/<run_id>/artifacts.tar.zst"
   }
 }
@@ -276,13 +278,15 @@ Before upload, the normalizer must redact or exclude:
 - unpublished solution files or verifier internals that would weaken future
   benchmark integrity
 
-Public artifacts should favor verifier summaries and high-level logs over raw
-agent transcripts until transcript publication rules are defined.
+Public per-task artifacts include the normalized agent summary and verifier
+summary. Those summaries may include agent trajectory, Codex execution log, and
+verifier logs when generated from a benchmark run that is intended for public
+publication. They must still exclude credentials, kubeconfigs, private payloads,
+and unpublished solution material.
 
-Raw Harbor job archives, full agent transcripts, and full verifier logs should
-not be exposed through public marketing links by default. They may still be
-uploaded to restricted storage for audit and debugging when access controls are
-configured outside this repository.
+Raw Harbor job archives should not be exposed through public marketing links by
+default. They may still be uploaded to restricted storage for audit and
+debugging when access controls are configured outside this repository.
 
 ## Marketing Site Contract
 
@@ -306,7 +310,7 @@ should consume only normalized D1 rows and R2 JSON summaries.
 2. Add a local normalizer that reads Harbor job folders and emits JSON without
    uploading. Done.
 3. Add fixture-based tests for normalizer behavior. Done.
-4. Add an R2 upload mode gated by explicit Cloudflare credentials.
+4. Add an R2 upload mode gated by explicit Cloudflare credentials. Done.
 5. Add a D1 write mode gated by explicit Cloudflare credentials. The local
    normalizer already emits `d1-upsert.sql` for deterministic loading.
 6. Add a dry-run command for CI validation. Done.


### PR DESCRIPTION
## Summary
- document the full D1/R2/marketing publish workflow for current benchmark runs
- include shared environment exports, normalization commands, D1 upserts, R2 artifact upload, and marketing JSON regeneration
- update the benchmark publishing spec to include summary.json and current public artifact behavior

## Verification
- ./scripts/lint-files.sh
- ./scripts/validate-structure.sh
- python3 scripts/check-dataset-manifests.py