### PR TITLE
docs: add Harbor model command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ Run a local Kubernetes benchmark task with Harbor:
 
 ```bash
 uvx --from harbor harbor run \
-  --job-name kubernetes-core-local-smoke \
-  -p datasets/kubernetes-core \
-  -a codex \
-  -m gpt-5.5 \
-  --ak reasoning_effort=high \
+  --job-name <job-name> \
+  -p <dataset-path> \
+  -a <agent-name> \
+  -m <model-name> \
   -e docker \
   -n 1 \
   -y \
   --max-retries 0 \
-  -i fix-crashloop-env-var
+  -i <task-name>
 ```
+
+For model-specific examples, including Codex reasoning settings and Gemini CLI
+workspace approval, see [Harbor model commands](docs/harbor-model-commands.md).
 
 For repeated local `kubernetes-core` runs, configure k3s registry
 authentication first so the ephemeral clusters can authenticate their own Docker

--- a/docs/harbor-model-commands.md
+++ b/docs/harbor-model-commands.md
@@ -1,0 +1,138 @@
+# Harbor Model Commands
+
+Use these commands from the repository root. Replace the placeholder values
+before running.
+
+## Generic Task Run
+
+```bash
+uvx --from harbor harbor run \
+  --job-name <job-name> \
+  -p <dataset-path> \
+  -a <agent-name> \
+  -m <model-name> \
+  -e docker \
+  -n <task-count> \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
+
+Examples of common placeholders:
+
+| Placeholder | Example |
+| --- | --- |
+| `<job-name>` | `kubernetes-core-codex-gpt-5-5-high` |
+| `<dataset-path>` | `datasets/kubernetes-core` |
+| `<agent-name>` | `codex` |
+| `<model-name>` | `gpt-5.5` |
+| `<task-count>` | `1` for one selected task, or omit `-i <task-name>` and use the number of tasks to sample |
+| `<task-name>` | `fix-crashloop-env-var` |
+
+For repeated local `kubernetes-core` runs, configure Docker Hub registry
+authentication first. See [k3s registry authentication](k3s-registry-auth.md).
+
+## Codex
+
+Run GPT-5.5 with high reasoning:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-codex-gpt-5-5-high \
+  -p datasets/kubernetes-core \
+  -a codex \
+  -m gpt-5.5 \
+  --ak reasoning_effort=high \
+  -e docker \
+  -n 58 \
+  -y \
+  --max-retries 0
+```
+
+Run GPT-5.5 with medium reasoning:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-codex-gpt-5-5-medium \
+  -p datasets/kubernetes-core \
+  -a codex \
+  -m gpt-5.5 \
+  --ak reasoning_effort=medium \
+  -e docker \
+  -n 58 \
+  -y \
+  --max-retries 0
+```
+
+Run a single Codex task:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-codex-gpt-5-5-high-<task-name> \
+  -p datasets/kubernetes-core \
+  -a codex \
+  -m gpt-5.5 \
+  --ak reasoning_effort=high \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
+
+## Gemini CLI
+
+Gemini CLI must be trusted and allowed to approve tool calls. Without these
+agent settings, Harbor runs can fail with `NonZeroAgentExitCodeError`.
+
+Run Gemini 3 Flash Preview on the full Kubernetes dataset:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-gemini-3-flash-preview \
+  -p datasets/kubernetes-core \
+  -a gemini-cli \
+  -m google/gemini-3-flash-preview \
+  --ae GEMINI_CLI_TRUST_WORKSPACE=true \
+  --ak approval_mode=yolo \
+  -e docker \
+  -n 58 \
+  -y \
+  --max-retries 0
+```
+
+Run a single Gemini task:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-gemini-3-flash-preview-<task-name> \
+  -p datasets/kubernetes-core \
+  -a gemini-cli \
+  -m google/gemini-3-flash-preview \
+  --ae GEMINI_CLI_TRUST_WORKSPACE=true \
+  --ak approval_mode=yolo \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
+
+If the installed Harbor/Gemini adapter expects a different approval key, use
+`--ak yolo=true` instead of `--ak approval_mode=yolo`.
+
+## Oracle
+
+Use the oracle agent to sanity-check a task against its reference solution:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-oracle-<task-name> \
+  -p datasets/kubernetes-core \
+  -a oracle \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```


### PR DESCRIPTION
## Summary

- Add a Harbor model command reference with generic, Codex, Gemini CLI, and oracle run commands.
- Document Gemini CLI trust and approval flags to avoid `NonZeroAgentExitCodeError` during benchmark runs.
- Generalize the README quickstart command with placeholders and link to the new command reference.

## Validation

- `./scripts/validate-structure.sh`
- `git diff --check`
