### PR TITLE
fix(results): include agent transcript fallbacks

### DIFF
--- a/docs/harbor-model-commands.md
+++ b/docs/harbor-model-commands.md
@@ -28,6 +28,26 @@ Examples of common placeholders:
 | `<parallel-task-count>` | `1` to run tasks one at a time |
 | `<task-name>` | `fix-crashloop-env-var` |
 
+Common agent names:
+
+| Agent | Harbor agent name |
+| --- | --- |
+| Codex | `codex` |
+| Gemini CLI | `gemini-cli` |
+| Claude Code | `claude-code` |
+| OpenCode | `opencode` |
+| Kimi CLI | `kimi-cli` |
+| Mini SWE Agent | `mini-swe-agent` |
+
+Recommended agents for non-default providers:
+
+| Provider family | Recommended Harbor agent | Model format |
+| --- | --- | --- |
+| DeepSeek | `opencode` | `deepseek/<model-name>` |
+| Mistral | `opencode` | `mistral/<model-name>` |
+| Z.ai | `mini-swe-agent` | `zai/<model-name>` |
+| Moonshot AI / Kimi K | `kimi-cli` | `moonshot/<model-name>` or `kimi/<model-name>` |
+
 Without `-i <task-name>`, Harbor runs the full dataset. Add `-i <task-name>` to
 run only one selected task.
 
@@ -123,6 +143,138 @@ uvx --from harbor harbor run \
 
 If the installed Harbor/Gemini adapter expects a different approval key, use
 `--ak yolo=true` instead of `--ak approval_mode=yolo`.
+
+## Claude Code
+
+Run Claude Code on the full Kubernetes dataset, one task at a time:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-claude-code-<model-name> \
+  -p datasets/kubernetes-core \
+  -a claude-code \
+  -m <model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0
+```
+
+Run a single Claude Code task:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-claude-code-<model-name>-<task-name> \
+  -p datasets/kubernetes-core \
+  -a claude-code \
+  -m <model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
+
+## OpenCode
+
+Use OpenCode for providers it supports directly, including DeepSeek and
+Mistral.
+
+Run the full Kubernetes dataset with OpenCode, one task at a time:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-opencode-<provider>-<model-name> \
+  -p datasets/kubernetes-core \
+  -a opencode \
+  -m <provider>/<model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0
+```
+
+Run a single OpenCode task:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-opencode-<provider>-<model-name>-<task-name> \
+  -p datasets/kubernetes-core \
+  -a opencode \
+  -m <provider>/<model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
+
+## Kimi CLI
+
+Use Kimi CLI for Moonshot AI and Kimi K models.
+
+Run the full Kubernetes dataset with Kimi CLI, one task at a time:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-kimi-cli-<model-name> \
+  -p datasets/kubernetes-core \
+  -a kimi-cli \
+  -m moonshot/<model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0
+```
+
+Run a single Kimi CLI task:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-kimi-cli-<model-name>-<task-name> \
+  -p datasets/kubernetes-core \
+  -a kimi-cli \
+  -m moonshot/<model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
+
+## Mini SWE Agent
+
+Use Mini SWE Agent for LiteLLM-backed providers without a more specific Harbor
+CLI adapter, including Z.ai.
+
+Run the full Kubernetes dataset with Mini SWE Agent, one task at a time:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-mini-swe-agent-<provider>-<model-name> \
+  -p datasets/kubernetes-core \
+  -a mini-swe-agent \
+  -m <provider>/<model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0
+```
+
+Run a single Mini SWE Agent task:
+
+```bash
+uvx --from harbor harbor run \
+  --job-name kubernetes-core-mini-swe-agent-<provider>-<model-name>-<task-name> \
+  -p datasets/kubernetes-core \
+  -a mini-swe-agent \
+  -m <provider>/<model-name> \
+  -e docker \
+  -n 1 \
+  -y \
+  --max-retries 0 \
+  -i <task-name>
+```
 
 ## Oracle
 

--- a/scripts/normalize-benchmark-run.py
+++ b/scripts/normalize-benchmark-run.py
@@ -35,6 +35,14 @@ import tomllib
 SCHEMA_VERSION = "1.0"
 UTC_FORMAT = "%Y-%m-%dT%H%M%SZ"
 CONSOLE = Console(stderr=True)
+AGENT_LOG_FILENAMES = (
+    "codex.txt",
+    "gemini-cli.txt",
+    "claude-code.txt",
+    "opencode.txt",
+    "kimi-cli.txt",
+    "mini-swe-agent.txt",
+)
 
 
 @dataclass(frozen=True)
@@ -149,6 +157,18 @@ def read_text_if_present(path: Path) -> str | None:
     if not path.exists():
         return None
     return path.read_text(errors="replace")
+
+
+def read_first_agent_log(trial_dir: Path) -> tuple[str | None, str | None]:
+    """Read the first public text transcript emitted by known agent harnesses."""
+
+    agent_dir = trial_dir / "agent"
+    for name in AGENT_LOG_FILENAMES:
+        content = read_text_if_present(agent_dir / name)
+        if content is not None:
+            return name, content
+
+    return None, None
 
 
 def load_dataset_name(dataset_path: Path) -> str:
@@ -499,6 +519,7 @@ def normalize_trial(
         "test_stdout": read_text_if_present(trial_dir / "verifier" / "test-stdout.txt"),
         "debug_log": read_text_if_present(trial_dir / "verifier" / "debug.log"),
     }
+    agent_log_name, agent_log = read_first_agent_log(trial_dir)
     agent_summary = {
         "schema_version": SCHEMA_VERSION,
         "task_name": task.name,
@@ -507,6 +528,8 @@ def normalize_trial(
         "finished_at": finished,
         "duration_sec": duration,
         "raw_transcript_public": True,
+        "agent_log_name": agent_log_name,
+        "agent_log": agent_log,
         "codex_log": read_text_if_present(trial_dir / "agent" / "codex.txt"),
         "trajectory": read_json_if_present(trial_dir / "agent" / "trajectory.json")
         or None,

--- a/scripts/test-benchmark-results-normalizer.py
+++ b/scripts/test-benchmark-results-normalizer.py
@@ -187,6 +187,8 @@ def test_normalizer_writes_public_contract() -> None:
             ).read_text()
         )
         assert agent_summary["raw_transcript_public"] is True
+        assert agent_summary["agent_log_name"] == "codex.txt"
+        assert agent_summary["agent_log"] == "agent transcript\n"
         assert agent_summary["codex_log"] == "agent transcript\n"
         assert agent_summary["trajectory"]["schema_version"] == "ATIF-v1.5"
         assert verifier_summary["duration_sec"] == 15


### PR DESCRIPTION
## Summary

- Include a generic public `agent_log` and `agent_log_name` in normalized agent summaries.
- Move known text transcript filenames into an `AGENT_LOG_FILENAMES` constant.
- Read transcripts from Codex, Gemini CLI, Claude Code, OpenCode, Kimi CLI, and Mini SWE Agent output files.
- Add Harbor command guidance for Claude Code, OpenCode, Kimi CLI, and Mini SWE Agent.
- Document recommended agents for DeepSeek, Mistral, Z.ai, and Moonshot AI / Kimi K models.

## Why

Several benchmark agents emit plain transcript files rather than structured `agent/trajectory.json`. The previous normalizer uploaded `agent-summary.json` files with `trajectory: null` and no usable generic transcript, so downstream dashboards could not show agent output for those runs.

## Provider mapping

- DeepSeek: `opencode` with `deepseek/<model-name>`
- Mistral: `opencode` with `mistral/<model-name>`
- Z.ai: `mini-swe-agent` with `zai/<model-name>`
- Moonshot AI / Kimi K: `kimi-cli` with `moonshot/<model-name>` or `kimi/<model-name>`

## Validation

- `python3 scripts/test-benchmark-results-normalizer.py`
