### PR TITLE
fix(ci): recognize Depot actionlint runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
 self-hosted-runner:
   labels:
-    - kubeply-arm64-low-latency
-    - kubeply-infra-bench
+    - depot-ubuntu-24.04


### PR DESCRIPTION
## Summary

Update `.github/actionlint.yaml` so actionlint recognizes the Depot runner label now used by the repository workflows.

## Root cause

The workflows were migrated to `runs-on: depot-ubuntu-24.04`, but actionlint still only allowed the old Kubeply self-hosted runner labels. That caused actionlint to reject the current workflow runner label.

## Validation

- `/tmp/actionlint-local/actionlint` using pinned actionlint `v1.7.12`
- `git diff --check`

Note: `./scripts/lint-files.sh` currently reports that `scripts/normalize-benchmark-run.py` would be reformatted. That file is unrelated and was not changed in this PR.
