### PR TITLE
fix(ci): install lint dependencies on Depot runner

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -17,6 +17,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=rhysd/actionlint
   ACTIONLINT_VERSION: v1.7.12
+  # renovate: datasource=pypi depName=uv
+  UV_VERSION: 0.11.8
 
 jobs:
   actionlint:
@@ -62,6 +64,18 @@ jobs:
     runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Install system lint dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends jq shellcheck
 
       - name: Validate file formatting and lint
         run: ./scripts/lint-files.sh

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -78,8 +78,8 @@ jobs:
       - name: Install system lint dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends jq shellcheck
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends jq shellcheck
 
       - name: Validate file formatting and lint
         run: ./scripts/lint-files.sh

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -17,6 +17,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=rhysd/actionlint
   ACTIONLINT_VERSION: v1.7.12
+  # renovate: datasource=github-releases depName=oven-sh/bun
+  BUN_VERSION: 1.3.10
   # renovate: datasource=pypi depName=uv
   UV_VERSION: 0.11.8
 
@@ -66,6 +68,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/scripts/normalize-benchmark-run.py
+++ b/scripts/normalize-benchmark-run.py
@@ -746,25 +746,43 @@ def build_documents(
     total_duration = sum(durations) if durations else None
     has_input_tokens = any(result.input_tokens is not None for result in trial_results)
     has_cache_tokens = any(result.cache_tokens is not None for result in trial_results)
-    has_output_tokens = any(result.output_tokens is not None for result in trial_results)
+    has_output_tokens = any(
+        result.output_tokens is not None for result in trial_results
+    )
     has_total_tokens = any(result.total_tokens is not None for result in trial_results)
     input_tokens = (
-        sum(result.input_tokens for result in trial_results if result.input_tokens is not None)
+        sum(
+            result.input_tokens
+            for result in trial_results
+            if result.input_tokens is not None
+        )
         if has_input_tokens
         else None
     )
     cache_tokens = (
-        sum(result.cache_tokens for result in trial_results if result.cache_tokens is not None)
+        sum(
+            result.cache_tokens
+            for result in trial_results
+            if result.cache_tokens is not None
+        )
         if has_cache_tokens
         else None
     )
     output_tokens = (
-        sum(result.output_tokens for result in trial_results if result.output_tokens is not None)
+        sum(
+            result.output_tokens
+            for result in trial_results
+            if result.output_tokens is not None
+        )
         if has_output_tokens
         else None
     )
     total_tokens = (
-        sum(result.total_tokens for result in trial_results if result.total_tokens is not None)
+        sum(
+            result.total_tokens
+            for result in trial_results
+            if result.total_tokens is not None
+        )
         if has_total_tokens
         else None
     )


### PR DESCRIPTION
## Summary
- install Bun, uv, jq, and shellcheck explicitly before fast-checks on Depot runners
- apply the ruff formatter change required by the pinned CI formatter

## Root cause
The latest Depot runner migration removed implicit access to bunx, so fast-checks failed immediately in scripts/lint-files.sh. Once that dependency is present, the pinned ruff format check also rejects scripts/normalize-benchmark-run.py.

## Validation
- ./scripts/lint-files.sh
- bash -n scripts/validate-structure.sh datasets/kubernetes-core/*/environment/scripts/* datasets/kubernetes-core/*/tests/*.sh datasets/kubernetes-core/*/solution/solve.sh
- ./scripts/validate-structure.sh
- python3 scripts/test-benchmark-results-normalizer.py
- python3 scripts/lint-kubernetes-rbac.py
- python3 scripts/check-dataset-manifests.py
- actionlint v1.7.12
- uvx --from harbor harbor sync datasets/kubernetes-core
- uvx --from harbor harbor sync datasets/terraform-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced PR validation workflow: pinned runtime/tool versions and added setup steps to install Bun, the uv package manager, and system lint utilities (jq, shellcheck) before running formatting, linting, and validation.

* **Refactor**
  * Rewrote benchmark normalization logic for improved readability while preserving existing behavior and output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubeply/infra-bench/pull/203)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubeply/infra-bench/pull/203)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->