### PR TITLE
fix(ci): recognize Depot actionlint runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
 self-hosted-runner:
   labels:
-    - kubeply-arm64-low-latency
-    - kubeply-infra-bench
+    - depot-ubuntu-24.04


### PR DESCRIPTION
## Summary
- Recognize the Depot actionlint runner in infra-bench CI.

## Validation
- Not run locally; publishing existing clean worktree branch so CI can validate the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD runner configuration labels for improved infrastructure consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kubeply/infra-bench/pull/204)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->