### PR TITLE
ci: use Depot runners

### DIFF
--- a/.github/workflows/oracle-validation.yaml
+++ b/.github/workflows/oracle-validation.yaml
@@ -20,9 +20,7 @@ concurrency:
 jobs:
   kubernetes-core-oracle:
     if: ${{ inputs.run_oracle }}
-    runs-on:
-      group: kubeply-low-latency
-      labels: kubeply-arm64-low-latency
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -24,9 +24,7 @@ jobs:
       github.event_name == 'push' ||
       (!github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on:
-      group: kubeply-low-latency
-      labels: kubeply-arm64-low-latency
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -61,9 +59,7 @@ jobs:
       github.event_name == 'push' ||
       (!github.event.pull_request.draft &&
       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on:
-      group: kubeply-low-latency
-      labels: kubeply-infra-bench
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary
- Move infra-bench CI jobs to Depot runners.

## Validation
- Not run locally; publishing existing clean worktree branch so CI can validate the PR.
