### PR TITLE
ci: use rudolint v1 action

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -19,6 +19,8 @@ env:
   ACTIONLINT_VERSION: v1.7.12
   # renovate: datasource=github-releases depName=oven-sh/bun
   BUN_VERSION: 1.3.10
+  # renovate: datasource=github-releases depName=kubeply/rudolint
+  RUDOLINT_VERSION: v1.0.0
   # renovate: datasource=pypi depName=uv
   UV_VERSION: 0.11.16
 
@@ -71,6 +73,7 @@ jobs:
 
       - uses: kubeply/rudolint@v1
         with:
+          version: ${{ env.RUDOLINT_VERSION }}
           config: .rudolint.yaml
           paths: |
             datasets

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -19,8 +19,6 @@ env:
   ACTIONLINT_VERSION: v1.7.12
   # renovate: datasource=github-releases depName=oven-sh/bun
   BUN_VERSION: 1.3.10
-  # renovate: datasource=github-releases depName=kubeply/rudolint
-  RUDOLINT_VERSION: v0.1.0
   # renovate: datasource=pypi depName=uv
   UV_VERSION: 0.11.16
 
@@ -71,9 +69,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: kubeply/rudolint@ae67cdb271b99a3bca5762c6ec5a28793b3d2910 # v0.1.0
+      - uses: kubeply/rudolint@v1
         with:
-          version: ${{ env.RUDOLINT_VERSION }}
           config: .rudolint.yaml
           paths: |
             datasets

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -19,8 +19,6 @@ env:
   ACTIONLINT_VERSION: v1.7.12
   # renovate: datasource=github-releases depName=oven-sh/bun
   BUN_VERSION: 1.3.10
-  # renovate: datasource=github-releases depName=kubeply/rudolint
-  RUDOLINT_VERSION: v1.0.0
   # renovate: datasource=pypi depName=uv
   UV_VERSION: 0.11.16
 
@@ -71,9 +69,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: kubeply/rudolint@v1
+      - uses: kubeply/rudolint@ef6bac6f06175688479491999f632f167f971f3e # v1.0.0
         with:
-          version: ${{ env.RUDOLINT_VERSION }}
           config: .rudolint.yaml
           paths: |
             datasets


### PR DESCRIPTION
## Summary

Updates the `dockerfile-lint` CI job to use the stable `kubeply/rudolint@v1` GitHub Action.

This removes the old `RUDOLINT_VERSION` environment pin and lets the v1 action install its default latest released linter binary, keeping the wrapper and binary aligned with the released action contract.

## Validation

- `actionlint`
- `./scripts/lint-files.sh`
- `./scripts/validate-structure.sh`
- `git diff --check`
