### PR TITLE
ci: update rudolint action config

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: kubeply/rudolint@ef6bac6f06175688479491999f632f167f971f3e # v1.0.0
+      - uses: kubeply/rudolint@67651f8afff6fb593967f8b9728cbdef6150eede # v1.2.0
         with:
           config: .rudolint.yaml
           paths: |

--- a/.rudolint.yaml
+++ b/.rudolint.yaml
@@ -5,5 +5,5 @@
 # The apt lists directory is mounted as a BuildKit cache in task images, so
 # deleting it inside the RUN step would clear the cache that repeat builds use.
 ignore:
-  - RDL3008
-  - RDL3009
+  - DL3008
+  - DL3009


### PR DESCRIPTION
## Summary

Updates the `dockerfile-lint` CI job to the `kubeply/rudolint` v1.2.0 action commit and migrates the local `.rudolint.yaml` ignores from the old `RDL3008`/`RDL3009` IDs to the current Hadolint-compatible `DL3008`/`DL3009` IDs.

This includes the action bump from Renovate PR #218 plus the config fix needed for the upgraded linter to keep the existing apt package/version policy exclusions working.

## Validation

- `actionlint`
- `./scripts/lint-files.sh`
- `./scripts/validate-structure.sh`
- Downloaded `rudolint` v1.2.0, verified the release checksum, and ran `rudolint check --config .rudolint.yaml datasets docs/templates`
