### PR TITLE
fix(kubernetes-core): stabilize gpu batch oracle check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Dataset | 🟢 Easy | 🟡 Medium | 🔴 Hard | Status |
 | --- | ---: | ---: | ---: | --- |
-| [`kubeply/kubernetes-core`](datasets/kubernetes-core) | 22 | 25 | 16 | 🛠️ Working |
+| [`kubeply/kubernetes-core`](datasets/kubernetes-core) | 22 | 25 | 22 | 🛠️ Working |
 | [`kubeply/terraform-core`](datasets/terraform-core) | 0 | 0 | 0 | 🛠️ Working |
 | `kubeply/observability-core` | 0 | 0 | 0 | ⏳ Not started yet |
 

--- a/datasets/kubernetes-core/dataset.toml
+++ b/datasets/kubernetes-core/dataset.toml
@@ -253,7 +253,7 @@ digest = "sha256:ce580ffab2c9ac72e3a6b0560dc3e542e0755bba825e4d02385c8208be666d4
 
 [[tasks]]
 name = "kubeply/restore-gpu-inference-batch-capacity"
-digest = "sha256:7ce879221b3d2926e4a2663be1bf8a4f7d82cec7b96062f111267a05a0d77b77"
+digest = "sha256:60f4f07c5303f99c328b9b6768998a8ae2e387266670644e7a2a1cca373a05f8"
 
 [[tasks]]
 name = "kubeply/clear-upgrade-preflight-live-compatibility"

--- a/datasets/kubernetes-core/restore-gpu-inference-batch-capacity/tests/test_gpu_inference_batch.sh
+++ b/datasets/kubernetes-core/restore-gpu-inference-batch-capacity/tests/test_gpu_inference_batch.sh
@@ -116,8 +116,9 @@ for pod in $(kubectl -n "$namespace" get pods -l app=nightly-inference-batch -o 
   [[ "$pod_node" == "$gpu_node" && "$owner_kind" == "Job" ]] || fail "inference pod $pod ran on $pod_node with owner $owner_kind"
 done
 
-while IFS='|' read -r pod_name pod_app pod_node owner_kind; do
+while IFS='|' read -r pod_name pod_app pod_node owner_kind deletion_timestamp; do
   [[ -z "$pod_name" ]] && continue
+  [[ -z "$deletion_timestamp" ]] || continue
   case "$pod_app" in
     web-api|image-prep-worker|cpu-image-prep)
       [[ "$pod_node" == "$general_node" ]] || fail "CPU-only pod $pod_name ran on $pod_node"
@@ -126,7 +127,7 @@ while IFS='|' read -r pod_name pod_app pod_node owner_kind; do
   [[ "$owner_kind" == "ReplicaSet" || "$owner_kind" == "Job" ]] || fail "unexpected owner for $pod_name: $owner_kind"
 done < <(
   kubectl -n "$namespace" get pods \
-    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.labels.app}{"|"}{.spec.nodeName}{"|"}{.metadata.ownerReferences[0].kind}{"\n"}{end}'
+    -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.labels.app}{"|"}{.spec.nodeName}{"|"}{.metadata.ownerReferences[0].kind}{"|"}{.metadata.deletionTimestamp}{"\n"}{end}'
 )
 
 echo "gpu inference batch completed while CPU-only work stayed on general capacity"


### PR DESCRIPTION
## Summary
- update the README kubernetes-core difficulty counts to 22 easy / 25 medium / 22 hard
- ignore terminating pods in the GPU batch verifier CPU-only placement check
- refresh the restore-gpu-inference-batch-capacity dataset digest

## Oracle
Ran oracle for the six newly merged hard tasks:
- clear-upgrade-preflight-live-compatibility: 1.0
- recover-apps-after-dns-cache-rollout: 1.0
- recover-ingress-controller-after-values-upgrade: 1.0
- recover-maintenance-cronjob-rbac-config: 1.0
- restore-edge-tls-certificate-route: 1.0
- restore-gpu-inference-batch-capacity: initially 0.0 due to verifier counting a terminating rollout pod, then 1.0 after this fix

## Validation
- ./scripts/lint-files.sh
- ./scripts/validate-structure.sh
- bash -n restore-gpu scripts
- python3 scripts/lint-kubernetes-rbac.py && git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved pod verification testing to correctly handle terminating Kubernetes pods by capturing deletion timestamps.

* **Chores**
  * Expanded Hard-difficulty dataset tasks from 16 to 22 entries.
  * Updated task validation checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->